### PR TITLE
Support for 'class' definitions

### DIFF
--- a/src/water/compiler/FileContext.java
+++ b/src/water/compiler/FileContext.java
@@ -4,6 +4,7 @@ import water.compiler.compiler.Context;
 import water.compiler.parser.Node;
 
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -15,14 +16,14 @@ import java.util.Properties;
 public class FileContext {
 	private final Node ast;
 	private final Context context;
-	private final Class<?> klass;
+	private final Map<String, Class<?>> classMap;
 	private final Path path;
 	private final Properties optimizations;
 
-	public FileContext(Node ast, Context context, Class<?> klass, Path path, Properties optimizations) {
+	public FileContext(Node ast, Context context, Map<String, Class<?>> classMap, Path path, Properties optimizations) {
 		this.ast = ast;
 		this.context = context;
-		this.klass = klass;
+		this.classMap = classMap;
 		this.path = path;
 		this.optimizations = optimizations;
 	}
@@ -35,12 +36,16 @@ public class FileContext {
 		return context;
 	}
 
-	public Class<?> getKlass() {
-		return klass;
+	public Map<String, Class<?>> getClassMap() {
+		return classMap;
 	}
 
 	public Path getPath() {
 		return path;
+	}
+
+	public Class<?> getCurrentClass() {
+		return classMap.get(context.getCurrentClass());
 	}
 
 	/**

--- a/src/water/compiler/Main.java
+++ b/src/water/compiler/Main.java
@@ -15,6 +15,7 @@ import water.compiler.parser.Node;
 import water.compiler.parser.Parser;
 import water.compiler.parser.UnexpectedTokenException;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -125,6 +126,7 @@ public class Main {
 			} catch (UnexpectedTokenException e) {
 				error(-1, e.getErrorMessage(path.toString()));
 			} catch (SemanticException e) {
+				e.printStackTrace();
 				error(-2, e.getErrorMessage(path.toString()));
 			}
 		}
@@ -137,16 +139,22 @@ public class Main {
 			try {
 				fc.getAst().visit(fc);
 			} catch (SemanticException e) {
+				e.printStackTrace();
 				error(-2, e.getErrorMessage(fc.getPath().toString()));
 			}
 
 			String outputDir = outputDirectory == null ? fc.getPath().getParent().toString() : outputDirectory;
-			String packageDir = fc.getContext().getPackageName();
+			String packageDir = fc.getContext().getPackageName().replace('/', File.separatorChar);
 
 			for(Map.Entry<String, Class<?>> classEntry : fc.getClassMap().entrySet()) {
-				byte[] klassRep = fc.getContext().getClassWriterMap().get(classEntry.getKey()).toByteArray();
+				String baseClassName = classEntry.getKey();
+				byte[] klassRep = fc.getContext().getClassWriterMap().get(baseClassName).toByteArray();
 
-				String className = classEntry.getKey() + ".class";
+				String className = baseClassName + ".class";
+
+				if(className.contains("/")) {
+					className = className.substring(className.lastIndexOf('/'));
+				}
 
 				Path classFile = Path.of(outputDir, packageDir, className);
 				try {

--- a/src/water/compiler/Main.java
+++ b/src/water/compiler/Main.java
@@ -126,7 +126,6 @@ public class Main {
 			} catch (UnexpectedTokenException e) {
 				error(-1, e.getErrorMessage(path.toString()));
 			} catch (SemanticException e) {
-				e.printStackTrace();
 				error(-2, e.getErrorMessage(path.toString()));
 			}
 		}
@@ -139,7 +138,6 @@ public class Main {
 			try {
 				fc.getAst().visit(fc);
 			} catch (SemanticException e) {
-				e.printStackTrace();
 				error(-2, e.getErrorMessage(fc.getPath().toString()));
 			}
 

--- a/src/water/compiler/Main.java
+++ b/src/water/compiler/Main.java
@@ -138,6 +138,7 @@ public class Main {
 			try {
 				fc.getAst().visit(fc);
 			} catch (SemanticException e) {
+				e.printStackTrace();
 				error(-2, e.getErrorMessage(fc.getPath().toString()));
 			}
 

--- a/src/water/compiler/PathConverter.java
+++ b/src/water/compiler/PathConverter.java
@@ -3,11 +3,8 @@ package water.compiler;
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.ParameterException;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 
 public class PathConverter implements IStringConverter<Path> {
 	@Override

--- a/src/water/compiler/compiler/Context.java
+++ b/src/water/compiler/compiler/Context.java
@@ -6,6 +6,7 @@ import org.objectweb.asm.MethodVisitor;
 import water.compiler.WaterClassLoader;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Provides information to the compiler about its current state
@@ -15,9 +16,9 @@ public class Context {
 	private final HashMap<String, String> imports;
 	private ContextType type;
 	private String source;
-	private String className;
 	private String packageName;
-	private ClassWriter classWriter;
+	private String currentClass;
+	private Map<String, ClassWriter> classWriterMap;
 	private MethodVisitor methodVisitor;
 	private MethodVisitor staticMethodVisitor;
 	private WaterClassLoader loader;
@@ -26,6 +27,7 @@ public class Context {
 
 	public Context() {
 		this.imports = new HashMap<>();
+		this.classWriterMap = new HashMap<>();
 		initImports();
 	}
 
@@ -45,14 +47,6 @@ public class Context {
 		this.source = source;
 	}
 
-	public String getClassName() {
-		return className;
-	}
-
-	public void setClassName(String className) {
-		this.className = className;
-	}
-
 	public String getPackageName() {
 		return packageName;
 	}
@@ -61,12 +55,16 @@ public class Context {
 		this.packageName = packageName;
 	}
 
-	public ClassWriter getClassWriter() {
-		return classWriter;
+	public String getCurrentClass() {
+		return currentClass;
 	}
 
-	public void setClassWriter(ClassWriter classWriter) {
-		this.classWriter = classWriter;
+	public void setCurrentClass(String currentClass) {
+		this.currentClass = currentClass;
+	}
+
+	public Map<String, ClassWriter> getClassWriterMap() {
+		return classWriterMap;
 	}
 
 	public MethodVisitor getMethodVisitor() {
@@ -112,6 +110,10 @@ public class Context {
 		MethodVisitor mv = type == ContextType.GLOBAL ? getStaticMethodVisitor() : getMethodVisitor();
 		mv.visitLabel(l);
 		mv.visitLineNumber(line, l);
+	}
+
+	public ClassWriter getCurrentClassWriter() {
+		return classWriterMap.get(currentClass);
 	}
 
 	private void initImports() {

--- a/src/water/compiler/compiler/Context.java
+++ b/src/water/compiler/compiler/Context.java
@@ -4,8 +4,10 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import water.compiler.WaterClassLoader;
+import water.compiler.parser.nodes.classes.ConstructorDeclarationNode;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -19,6 +21,7 @@ public class Context {
 	private String source;
 	private String packageName;
 	private String currentClass;
+	private List<ConstructorDeclarationNode> constructors;
 	private MethodVisitor methodVisitor;
 	private MethodVisitor staticMethodVisitor;
 	private MethodVisitor defaultConstructor;
@@ -63,6 +66,14 @@ public class Context {
 
 	public void setCurrentClass(String currentClass) {
 		this.currentClass = currentClass;
+	}
+
+	public List<ConstructorDeclarationNode> getConstructors() {
+		return constructors;
+	}
+
+	public void setConstructors(List<ConstructorDeclarationNode> constructors) {
+		this.constructors = constructors;
 	}
 
 	public Map<String, ClassWriter> getClassWriterMap() {

--- a/src/water/compiler/compiler/Context.java
+++ b/src/water/compiler/compiler/Context.java
@@ -14,16 +14,17 @@ import java.util.Map;
  */
 public class Context {
 	private final HashMap<String, String> imports;
+	private final Map<String, ClassWriter> classWriterMap;
 	private ContextType type;
 	private String source;
 	private String packageName;
 	private String currentClass;
-	private Map<String, ClassWriter> classWriterMap;
 	private MethodVisitor methodVisitor;
 	private MethodVisitor staticMethodVisitor;
 	private MethodVisitor defaultConstructor;
 	private WaterClassLoader loader;
 	private Scope scope;
+	private boolean isStaticMethod;
 	private int currentLine;
 
 	public Context() {
@@ -106,6 +107,14 @@ public class Context {
 
 	public void setScope(Scope scope) {
 		this.scope = scope;
+	}
+
+	public boolean isStaticMethod() {
+		return isStaticMethod;
+	}
+
+	public void setStaticMethod(boolean staticMethod) {
+		isStaticMethod = staticMethod;
 	}
 
 	public HashMap<String, String> getImports() {

--- a/src/water/compiler/compiler/Context.java
+++ b/src/water/compiler/compiler/Context.java
@@ -21,6 +21,7 @@ public class Context {
 	private Map<String, ClassWriter> classWriterMap;
 	private MethodVisitor methodVisitor;
 	private MethodVisitor staticMethodVisitor;
+	private MethodVisitor defaultConstructor;
 	private WaterClassLoader loader;
 	private Scope scope;
 	private int currentLine;
@@ -83,6 +84,14 @@ public class Context {
 		this.staticMethodVisitor = staticMethodVisitor;
 	}
 
+	public MethodVisitor getDefaultConstructor() {
+		return defaultConstructor;
+	}
+
+	public void setDefaultConstructor(MethodVisitor defaultConstructor) {
+		this.defaultConstructor = defaultConstructor;
+	}
+
 	public WaterClassLoader getLoader() {
 		return loader;
 	}
@@ -108,6 +117,7 @@ public class Context {
 		currentLine = line;
 		Label l = new Label();
 		MethodVisitor mv = type == ContextType.GLOBAL ? getStaticMethodVisitor() : getMethodVisitor();
+		if(mv == null) mv = getDefaultConstructor();
 		mv.visitLabel(l);
 		mv.visitLineNumber(line, l);
 	}

--- a/src/water/compiler/compiler/Function.java
+++ b/src/water/compiler/compiler/Function.java
@@ -42,7 +42,7 @@ public class Function {
 	public int getAccess() {
 		return switch (functionType) {
 			case STATIC -> Opcodes.INVOKESTATIC;
-			case SOUT -> Opcodes.INVOKEVIRTUAL;
+			case CLASS, SOUT -> Opcodes.INVOKEVIRTUAL;
 		};
 	}
 }

--- a/src/water/compiler/compiler/FunctionType.java
+++ b/src/water/compiler/compiler/FunctionType.java
@@ -5,6 +5,7 @@ package water.compiler.compiler;
  * sout allows the compiler to insert a 'System.out' access before the function - used for 'println' and related
  */
 public enum FunctionType {
+	CLASS,
 	STATIC,
 	SOUT
 }

--- a/src/water/compiler/compiler/Scope.java
+++ b/src/water/compiler/compiler/Scope.java
@@ -58,7 +58,9 @@ public class Scope {
 		}
 
 		for(Field f : klass.getDeclaredFields()) {
-			addVariable(new Variable(VariableType.GLOBAL, f.getName(), Type.getInternalName(klass), Type.getType(f.getType()), Modifier.isFinal(f.getModifiers())));
+			int modifier = f.getModifiers();
+			boolean isStatic = Modifier.isStatic(modifier);
+			addVariable(new Variable(isStatic ? VariableType.GLOBAL : VariableType.CLASS, f.getName(), Type.getInternalName(klass), Type.getType(f.getType()), Modifier.isFinal(f.getModifiers())));
 		}
 	}
 

--- a/src/water/compiler/compiler/Scope.java
+++ b/src/water/compiler/compiler/Scope.java
@@ -37,12 +37,13 @@ public class Scope {
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(Z)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(Ljava/lang/Object;)V")));
 
-		for(Method m : context.getKlass().getDeclaredMethods()) {
-			addFunction(new Function(FunctionType.STATIC, m.getName(), Type.getInternalName(context.getKlass()), Type.getType(m)));
+		Class<?> klass = context.getCurrentClass();
+		for(Method m : klass.getDeclaredMethods()) {
+			addFunction(new Function(FunctionType.STATIC, m.getName(), Type.getInternalName(klass), Type.getType(m)));
 		}
 
-		for(Field f : context.getKlass().getDeclaredFields()) {
-			addVariable(new Variable(VariableType.GLOBAL, f.getName(), Type.getInternalName(context.getKlass()), Type.getType(f.getType()), Modifier.isFinal(f.getModifiers())));
+		for(Field f : klass.getDeclaredFields()) {
+			addVariable(new Variable(VariableType.GLOBAL, f.getName(), Type.getInternalName(klass), Type.getType(f.getType()), Modifier.isFinal(f.getModifiers())));
 		}
 	}
 

--- a/src/water/compiler/compiler/Scope.java
+++ b/src/water/compiler/compiler/Scope.java
@@ -50,6 +50,7 @@ public class Scope {
 
 	public void updateCurrentClassMethods(FileContext context) {
 		Class<?> klass = context.getCurrentClass();
+		if(klass == null) return;
 		for(Method m : klass.getDeclaredMethods()) {
 			int modifier = m.getModifiers();
 			boolean isStatic = Modifier.isStatic(modifier);

--- a/src/water/compiler/compiler/Scope.java
+++ b/src/water/compiler/compiler/Scope.java
@@ -60,7 +60,7 @@ public class Scope {
 		for(Field f : klass.getDeclaredFields()) {
 			int modifier = f.getModifiers();
 			boolean isStatic = Modifier.isStatic(modifier);
-			addVariable(new Variable(isStatic ? VariableType.GLOBAL : VariableType.CLASS, f.getName(), Type.getInternalName(klass), Type.getType(f.getType()), Modifier.isFinal(f.getModifiers())));
+			addVariable(new Variable(isStatic ? VariableType.STATIC : VariableType.CLASS, f.getName(), Type.getInternalName(klass), Type.getType(f.getType()), Modifier.isFinal(f.getModifiers())));
 		}
 	}
 

--- a/src/water/compiler/compiler/Scope.java
+++ b/src/water/compiler/compiler/Scope.java
@@ -37,14 +37,7 @@ public class Scope {
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(Z)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(Ljava/lang/Object;)V")));
 
-		Class<?> klass = context.getCurrentClass();
-		for(Method m : klass.getDeclaredMethods()) {
-			addFunction(new Function(FunctionType.STATIC, m.getName(), Type.getInternalName(klass), Type.getType(m)));
-		}
-
-		for(Field f : klass.getDeclaredFields()) {
-			addVariable(new Variable(VariableType.GLOBAL, f.getName(), Type.getInternalName(klass), Type.getType(f.getType()), Modifier.isFinal(f.getModifiers())));
-		}
+		updateCurrentClassMethods(context);
 	}
 
 	public Scope(Context context) {
@@ -54,6 +47,19 @@ public class Scope {
 	}
 
 	private Scope() {}
+
+	public void updateCurrentClassMethods(FileContext context) {
+		Class<?> klass = context.getCurrentClass();
+		for(Method m : klass.getDeclaredMethods()) {
+			int modifier = m.getModifiers();
+			boolean isStatic = Modifier.isStatic(modifier);
+			addFunction(new Function(isStatic ? FunctionType.STATIC : FunctionType.CLASS, m.getName(), Type.getInternalName(klass), Type.getType(m)));
+		}
+
+		for(Field f : klass.getDeclaredFields()) {
+			addVariable(new Variable(VariableType.GLOBAL, f.getName(), Type.getInternalName(klass), Type.getType(f.getType()), Modifier.isFinal(f.getModifiers())));
+		}
+	}
 
 	public Scope nextDepth() {
 		Scope scope = new Scope();

--- a/src/water/compiler/compiler/VariableType.java
+++ b/src/water/compiler/compiler/VariableType.java
@@ -5,5 +5,6 @@ package water.compiler.compiler;
  */
 public enum VariableType {
 	GLOBAL,
+	CLASS,
 	LOCAL
 }

--- a/src/water/compiler/compiler/VariableType.java
+++ b/src/water/compiler/compiler/VariableType.java
@@ -4,7 +4,7 @@ package water.compiler.compiler;
  * Where the variable was declared - dictates how it should be accessed
  */
 public enum VariableType {
-	GLOBAL,
+	STATIC,
 	CLASS,
 	LOCAL
 }

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -151,6 +151,7 @@ public class Lexer {
 			case "boolean" -> TokenType.BOOLEAN;
 			case "public" -> TokenType.PUBLIC;
 			case "private" -> TokenType.PRIVATE;
+			case "static" -> TokenType.STATIC;
 			default -> TokenType.IDENTIFIER;
 		});
 	}

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -134,6 +134,7 @@ public class Lexer {
 			case "function" -> TokenType.FUNCTION;
 			case "var" -> TokenType.VAR;
 			case "const" -> TokenType.CONST;
+			case "class" -> TokenType.CLASS;
 			case "as" -> TokenType.AS;
 			case "return" -> TokenType.RETURN;
 			case "while" -> TokenType.WHILE;

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -135,6 +135,7 @@ public class Lexer {
 			case "var" -> TokenType.VAR;
 			case "const" -> TokenType.CONST;
 			case "class" -> TokenType.CLASS;
+			case "constructor" -> TokenType.CONSTRUCTOR;
 			case "as" -> TokenType.AS;
 			case "return" -> TokenType.RETURN;
 			case "while" -> TokenType.WHILE;

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -46,6 +46,7 @@ public enum TokenType {
 	BOOLEAN,
 	PUBLIC,
 	PRIVATE,
+	STATIC,
 
 	// Literals
 	NUMBER,

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -29,6 +29,7 @@ public enum TokenType {
 	FUNCTION,
 	VAR,
 	CONST,
+	CLASS,
 	AS,
 	RETURN,
 	FOR,

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -30,6 +30,7 @@ public enum TokenType {
 	VAR,
 	CONST,
 	CLASS,
+	CONSTRUCTOR,
 	AS,
 	RETURN,
 	FOR,

--- a/src/water/compiler/parser/Node.java
+++ b/src/water/compiler/parser/Node.java
@@ -23,4 +23,6 @@ public interface Node {
 	default LValue getLValue() { return LValue.NONE; }
 	/** Get data needed to assign to LValue */
 	default Object[] getLValueData() { return new Object[0]; }
+	/** If the Node produces a new class file */
+	default boolean isNewClass() { return false; }
 }

--- a/src/water/compiler/parser/Parser.java
+++ b/src/water/compiler/parser/Parser.java
@@ -5,6 +5,7 @@ import water.compiler.lexer.Token;
 import water.compiler.lexer.TokenType;
 import water.compiler.parser.nodes.block.BlockNode;
 import water.compiler.parser.nodes.block.ProgramNode;
+import water.compiler.parser.nodes.classes.ClassDeclarationNode;
 import water.compiler.parser.nodes.classes.MemberAccessNode;
 import water.compiler.parser.nodes.classes.MethodCallNode;
 import water.compiler.parser.nodes.classes.ObjectConstructorNode;
@@ -114,6 +115,7 @@ public class Parser {
 		Token tok = advance();
 		return switch(tok.getType()) {
 			case FUNCTION -> functionDeclaration(accessModifier);
+			case CLASS -> classDeclaration(accessModifier);
 			case VAR, CONST -> variableDeclaration(accessModifier);
 			default -> throw new UnexpectedTokenException(tok, "Expected declaration");
 		};
@@ -147,6 +149,15 @@ public class Parser {
 		}
 
 		return new FunctionDeclarationNode(type, name, body, parameters, returnType, access);
+	}
+
+	private Node classDeclaration(Token access) throws UnexpectedTokenException {
+		Token name = consume(TokenType.IDENTIFIER, "Expected class name");
+
+		consume(TokenType.LBRACE, "Expected '{' before class body");
+		consume(TokenType.RBRACE, "Expected '}' after class body");
+
+		return new ClassDeclarationNode(name, access);
 	}
 
 	/** Forms grammar: 'var' IDENTIFIER '=' expression ';' */

--- a/src/water/compiler/parser/Parser.java
+++ b/src/water/compiler/parser/Parser.java
@@ -55,6 +55,7 @@ public class Parser {
 	 */
 	private Node program() throws UnexpectedTokenException {
 		ArrayList<Node> declarations = new ArrayList<>();
+		ArrayList<Node> imports = new ArrayList<>();
 
 		Node packageName = null;
 
@@ -65,14 +66,14 @@ public class Parser {
 
 		// All import statements must appear at the top of the file, before standard declarations
 		while(!isAtEnd() && match(TokenType.IMPORT)) {
-			declarations.add(importStatement());
+			imports.add(importStatement());
 		}
 
 		// Top level declarations
 		while(!isAtEnd()) {
 			declarations.add(declaration());
 		}
-		return new ProgramNode(packageName, declarations);
+		return new ProgramNode(packageName, imports, declarations);
 	}
 
 	//============================ Special Statements =============================

--- a/src/water/compiler/parser/Parser.java
+++ b/src/water/compiler/parser/Parser.java
@@ -155,9 +155,16 @@ public class Parser {
 		Token name = consume(TokenType.IDENTIFIER, "Expected class name");
 
 		consume(TokenType.LBRACE, "Expected '{' before class body");
+
+		ArrayList<Node> declarations = new ArrayList<>();
+
+		while(!isAtEnd() && tokens.get(index).getType() != TokenType.RBRACE) {
+			declarations.add(declaration());
+		}
+
 		consume(TokenType.RBRACE, "Expected '}' after class body");
 
-		return new ClassDeclarationNode(name, access);
+		return new ClassDeclarationNode(name, declarations, access);
 	}
 
 	/** Forms grammar: 'var' IDENTIFIER '=' expression ';' */

--- a/src/water/compiler/parser/nodes/block/ProgramNode.java
+++ b/src/water/compiler/parser/nodes/block/ProgramNode.java
@@ -8,6 +8,7 @@ import water.compiler.compiler.Context;
 import water.compiler.compiler.ContextType;
 import water.compiler.compiler.SemanticException;
 import water.compiler.parser.Node;
+import water.compiler.parser.nodes.classes.ClassDeclarationNode;
 import water.compiler.parser.nodes.variable.VariableDeclarationNode;
 
 import java.util.List;
@@ -15,73 +16,97 @@ import java.util.stream.Collectors;
 
 public class ProgramNode implements Node {
 	private final List<Node> declarations;
+	private final List<Node> imports;
 	private final Node packageName;
 	/** This variable is true when a top level variable is present. Its use is to avoid unnecessary code generation. */
 	private boolean staticVariableInit = false;
+	/** Records if this program needs to generate a Wtr.class file, or if it only defines other classes */
+	// This behaviour is what causes the strange looking if statements, where different code only needs to happen for a standalone class.
+	private boolean standaloneClass = false;
 	
-	public ProgramNode(Node packageName, List<Node> declarations) {
+	public ProgramNode(Node packageName, List<Node> imports, List<Node> declarations) {
 		this.packageName = packageName;
+		this.imports = imports;
 		this.declarations = declarations;
 	}
 
 	@Override
 	public void preprocess(Context context) throws SemanticException {
-		ClassWriter writer = initClass(context);
-		
+		String packageN = packageName == null ? "" : packageName.getReturnType(context).getInternalName();
+		context.setPackageName(packageN);
+
+		String source = context.getSource();
+		String name = source.substring(0, source.indexOf(".")) + "Wtr";
+
+		standaloneClass = declarations.stream().filter(n -> !n.isNewClass()).toArray().length != 0;
+
+		ClassWriter writer = null;
+
+		if(standaloneClass) {
+			writer = initClass(name, context);
+		}
+
+		for(Node n : imports) n.preprocess(context);
+
 		for(Node n : declarations) {
 			n.preprocess(context);
 			if(n instanceof VariableDeclarationNode) staticVariableInit = true;
 		}
-		
-		if(staticVariableInit) {
-			MethodVisitor staticMethod = writer.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
-			staticMethod.visitCode();
-			staticMethod.visitInsn(Opcodes.RETURN);
-			staticMethod.visitMaxs(0, 0);
-			staticMethod.visitEnd();
-		}
 
-		writer.visitEnd();
+		if(standaloneClass) {
+			if(staticVariableInit) {
+				MethodVisitor staticMethod = writer.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
+				staticMethod.visitCode();
+				staticMethod.visitInsn(Opcodes.RETURN);
+				staticMethod.visitMaxs(0, 0);
+				staticMethod.visitEnd();
+			}
+
+			writer.visitEnd();
+		}
 	}
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
-
-		ClassWriter writer = initClass(context.getContext());
-
+		ClassWriter writer = null;
 		MethodVisitor staticMethod = null;
-		if(staticVariableInit) {
-			staticMethod = writer.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
-			context.getContext().setStaticMethodVisitor(staticMethod);
+		if(standaloneClass) {
+			String source = context.getContext().getSource();
+			String name = source.substring(0, source.indexOf(".")) + "Wtr";
 
-			staticMethod.visitCode();
+			writer = initClass(name, context.getContext());
+
+			if(staticVariableInit) {
+				staticMethod = writer.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
+				context.getContext().setStaticMethodVisitor(staticMethod);
+
+				staticMethod.visitCode();
+			}
 		}
 
 		for(Node n : declarations) {
 			n.visit(context);
 		}
-		
-		if(staticVariableInit) {
-			staticMethod.visitInsn(Opcodes.RETURN);
-			staticMethod.visitMaxs(0, 0);
-			staticMethod.visitEnd();
-		}
 
-		writer.visitEnd();
+		if(standaloneClass) {
+			if(staticVariableInit) {
+				staticMethod.visitInsn(Opcodes.RETURN);
+				staticMethod.visitMaxs(0, 0);
+				staticMethod.visitEnd();
+			}
+
+			writer.visitEnd();
+		}
 	}
 
-	private ClassWriter initClass(Context context) throws SemanticException {
+	private ClassWriter initClass(String name, Context context) throws SemanticException {
 		context.setType(ContextType.GLOBAL);
 
 		String source = context.getSource();
-		String name = source.substring(0, source.indexOf("."));
 
-		String packageN = packageName == null ? "" : packageName.getReturnType(context).getInternalName();
-
-		if(packageName != null) name = packageN + "/" + name;
+		if(packageName != null) name = context.getPackageName() + "/" + name;
 
 		context.setCurrentClass(name);
-		context.setPackageName(packageN);
 
 		ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
 

--- a/src/water/compiler/parser/nodes/block/ProgramNode.java
+++ b/src/water/compiler/parser/nodes/block/ProgramNode.java
@@ -80,7 +80,7 @@ public class ProgramNode implements Node {
 
 		if(packageName != null) name = packageN + "/" + name;
 
-		context.setClassName(name);
+		context.setCurrentClass(name);
 		context.setPackageName(packageN);
 
 		ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
@@ -89,7 +89,7 @@ public class ProgramNode implements Node {
 
 		writer.visitSource(source, null);
 
-		context.setClassWriter(writer);
+		context.getClassWriterMap().put(name, writer);
 
 		return writer;
 	}

--- a/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
@@ -6,28 +6,30 @@ import org.objectweb.asm.Opcodes;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.ContextType;
+import water.compiler.compiler.Scope;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.lexer.TokenType;
 import water.compiler.parser.Node;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ClassDeclarationNode implements Node {
 
 	private final Token name;
+	private final List<Node> declarations;
 	private final Token access;
 
-	public ClassDeclarationNode(Token name, Token access) {
+	public ClassDeclarationNode(Token name, List<Node> declarations, Token access) {
 		this.name = name;
+		this.declarations = declarations;
 		this.access = access;
 	}
 
 	@Override
-	public void visit(FileContext context) throws SemanticException {
-
-	}
-
-	@Override
-	public void preprocess(Context context) {
+	public void visit(FileContext fc) throws SemanticException {
+		Context context = fc.getContext();
 		ContextType prevType = context.getType();
 		String prevClass = context.getCurrentClass();
 
@@ -35,24 +37,60 @@ public class ClassDeclarationNode implements Node {
 
 		createDefaultConstructor(writer);
 
+		Scope outer = context.getScope();
+		context.setScope(outer.nextDepth());
+		context.getScope().updateCurrentClassMethods(fc);
+
+		for(Node declaration : declarations) {
+			declaration.visit(fc);
+		}
+
 		writer.visitEnd();
 
+		context.setScope(outer);
+		context.setType(prevType);
+		context.setCurrentClass(prevClass);
+	}
+
+	@Override
+	public void preprocess(Context context) throws SemanticException {
+		ContextType prevType = context.getType();
+		String prevClass = context.getCurrentClass();
+
+		ClassWriter writer = initClass(context);
+
+		createDefaultConstructor(writer);
+
+		Scope outer = context.getScope();
+		context.setScope(outer.nextDepth());
+
+		for(Node declaration : declarations) {
+			declaration.preprocess(context);
+		}
+
+		writer.visitEnd();
+
+		context.setScope(outer);
 		context.setType(prevType);
 		context.setCurrentClass(prevClass);
 	}
 
 	private ClassWriter initClass(Context context) {
 		context.setType(ContextType.CLASS);
-		//TODO Package name
-
 		int accessLevel = getAccessLevel();
 
-		String className = name.getValue();
+		String baseName = name.getValue();
+		String className = baseName;
 
 		// "private" class
 		if(accessLevel == 0) {
-			className = context.getCurrentClass() + "$" + className;
-			context.getImports().put(name.getValue(), className);
+			className = context.getCurrentClass() + "$" + baseName;
+		}
+		if(!context.getPackageName().isEmpty()) {
+			className = context.getPackageName() + "/" + className;
+		}
+		if(!className.equals(baseName)) {
+			context.getImports().put(baseName, className.replace('/', '.'));
 		}
 
 		context.setCurrentClass(className);
@@ -89,6 +127,6 @@ public class ClassDeclarationNode implements Node {
 
 	@Override
 	public String toString() {
-		return "class %s {}".formatted(name.getValue());
+		return "class %s {%s}".formatted(name.getValue(), declarations.stream().map(Node::toString).collect(Collectors.joining()));
 	}
 }

--- a/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
@@ -125,6 +125,15 @@ public class ClassDeclarationNode implements Node {
 		return 0;
 	}
 
+	public String getName() {
+		return name.getValue();
+	}
+
+	@Override
+	public boolean isNewClass() {
+		return true;
+	}
+
 	@Override
 	public String toString() {
 		return "class %s {%s}".formatted(name.getValue(), declarations.stream().map(Node::toString).collect(Collectors.joining()));

--- a/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
@@ -1,0 +1,94 @@
+package water.compiler.parser.nodes.classes;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import water.compiler.FileContext;
+import water.compiler.compiler.Context;
+import water.compiler.compiler.ContextType;
+import water.compiler.compiler.SemanticException;
+import water.compiler.lexer.Token;
+import water.compiler.lexer.TokenType;
+import water.compiler.parser.Node;
+
+public class ClassDeclarationNode implements Node {
+
+	private final Token name;
+	private final Token access;
+
+	public ClassDeclarationNode(Token name, Token access) {
+		this.name = name;
+		this.access = access;
+	}
+
+	@Override
+	public void visit(FileContext context) throws SemanticException {
+
+	}
+
+	@Override
+	public void preprocess(Context context) {
+		ContextType prevType = context.getType();
+		String prevClass = context.getCurrentClass();
+
+		ClassWriter writer = initClass(context);
+
+		createDefaultConstructor(writer);
+
+		writer.visitEnd();
+
+		context.setType(prevType);
+		context.setCurrentClass(prevClass);
+	}
+
+	private ClassWriter initClass(Context context) {
+		context.setType(ContextType.CLASS);
+		//TODO Package name
+
+		int accessLevel = getAccessLevel();
+
+		String className = name.getValue();
+
+		// "private" class
+		if(accessLevel == 0) {
+			className = context.getCurrentClass() + "$" + className;
+			context.getImports().put(name.getValue(), className);
+		}
+
+		context.setCurrentClass(className);
+
+		ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+
+		writer.visit(Opcodes.V9, accessLevel | Opcodes.ACC_SUPER, className, null, "java/lang/Object", null);
+
+		writer.visitSource(context.getSource(), null);
+
+		context.getClassWriterMap().put(className, writer);
+
+		return writer;
+	}
+
+	private MethodVisitor createDefaultConstructor(ClassWriter writer) {
+		MethodVisitor constructor = writer.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+		constructor.visitCode();
+
+		constructor.visitVarInsn(Opcodes.ALOAD, 0);
+		constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+		constructor.visitInsn(Opcodes.RETURN);
+
+		constructor.visitMaxs(0, 0);
+		constructor.visitEnd();
+
+		return constructor;
+	}
+
+	private int getAccessLevel() {
+		if(access == null || access.getType() == TokenType.PUBLIC) return Opcodes.ACC_PUBLIC;
+		return 0;
+	}
+
+	@Override
+	public String toString() {
+		return "class %s {}".formatted(name.getValue());
+	}
+}

--- a/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
@@ -35,7 +35,9 @@ public class ClassDeclarationNode implements Node {
 
 		ClassWriter writer = initClass(context);
 
-		createDefaultConstructor(writer);
+		MethodVisitor defaultConstructor = createDefaultConstructor(writer);
+
+		context.setDefaultConstructor(defaultConstructor);
 
 		Scope outer = context.getScope();
 		context.setScope(outer.nextDepth());
@@ -44,6 +46,10 @@ public class ClassDeclarationNode implements Node {
 		for(Node declaration : declarations) {
 			declaration.visit(fc);
 		}
+
+		defaultConstructor.visitInsn(Opcodes.RETURN);
+		defaultConstructor.visitMaxs(0, 0);
+		defaultConstructor.visitEnd();
 
 		writer.visitEnd();
 
@@ -59,7 +65,9 @@ public class ClassDeclarationNode implements Node {
 
 		ClassWriter writer = initClass(context);
 
-		createDefaultConstructor(writer);
+		MethodVisitor defaultConstructor = createDefaultConstructor(writer);
+
+		context.setDefaultConstructor(defaultConstructor);
 
 		Scope outer = context.getScope();
 		context.setScope(outer.nextDepth());
@@ -67,6 +75,10 @@ public class ClassDeclarationNode implements Node {
 		for(Node declaration : declarations) {
 			declaration.preprocess(context);
 		}
+
+		defaultConstructor.visitInsn(Opcodes.RETURN);
+		defaultConstructor.visitMaxs(0, 0);
+		defaultConstructor.visitEnd();
 
 		writer.visitEnd();
 
@@ -112,10 +124,6 @@ public class ClassDeclarationNode implements Node {
 
 		constructor.visitVarInsn(Opcodes.ALOAD, 0);
 		constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-		constructor.visitInsn(Opcodes.RETURN);
-
-		constructor.visitMaxs(0, 0);
-		constructor.visitEnd();
 
 		return constructor;
 	}

--- a/src/water/compiler/parser/nodes/classes/ConstructorDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/classes/ConstructorDeclarationNode.java
@@ -40,6 +40,7 @@ public class ConstructorDeclarationNode implements Node {
 
 		for(Node variable : variablesInit) {
 			variable.visit(fc);
+			context.setMethodVisitor(constructor);
 		}
 
 		context.getScope().setLocalIndex(1 + parameters.size());

--- a/src/water/compiler/parser/nodes/classes/ConstructorDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/classes/ConstructorDeclarationNode.java
@@ -1,0 +1,84 @@
+package water.compiler.parser.nodes.classes;
+
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import water.compiler.FileContext;
+import water.compiler.compiler.Context;
+import water.compiler.compiler.SemanticException;
+import water.compiler.compiler.Variable;
+import water.compiler.compiler.VariableType;
+import water.compiler.lexer.Token;
+import water.compiler.parser.Node;
+import water.compiler.util.Pair;
+import water.compiler.util.Unthrow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ConstructorDeclarationNode implements Node {
+	private final Token access;
+	private final List<Pair<Token, Node>> parameters;
+	private final Node body;
+	private final List<Node> variablesInit;
+
+	public ConstructorDeclarationNode(Token access, List<Pair<Token, Node>> parameters, Node body) {
+		this.access = access;
+		this.parameters = parameters;
+		this.body = body;
+		this.variablesInit = new ArrayList<>();
+	}
+
+	@Override
+	public void visit(FileContext fc) throws SemanticException {
+		Context context = fc.getContext();
+		MethodVisitor constructor = createConstructor(context);
+		context.setDefaultConstructor(constructor);
+		context.setMethodVisitor(constructor);
+
+		for(Node variable : variablesInit) {
+			variable.visit(fc);
+		}
+
+		context.getScope().setLocalIndex(1 + parameters.size());
+		context.getScope().addVariable(new Variable(VariableType.LOCAL, "this", 0, Type.getObjectType(context.getCurrentClass()), true));
+
+		for (int i = 0; i < parameters.size(); i++) {
+			Pair<Token, Node> parameter = parameters.get(i);
+
+			context.getScope().addVariable(new Variable(VariableType.LOCAL, parameter.getFirst().getValue(), i + 1, parameter.getSecond().getReturnType(context), false));
+		}
+
+		body.visit(fc);
+
+		constructor.visitInsn(Opcodes.RETURN);
+		constructor.visitMaxs(0, 0);
+		constructor.visitEnd();
+	}
+
+	@Override
+	public void preprocess(Context context) throws SemanticException {
+		MethodVisitor constructor = createConstructor(context);
+		constructor.visitInsn(Opcodes.RETURN);
+		constructor.visitMaxs(0, 0);
+		constructor.visitEnd();
+	}
+
+	private MethodVisitor createConstructor(Context context) {
+		ClassWriter writer = context.getCurrentClassWriter();
+		String args = parameters.stream().map(Pair::getSecond).map(n -> Unthrow.wrap(() -> n.getReturnType(context).getDescriptor())).collect(Collectors.joining());
+		MethodVisitor constructor = writer.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(" + args + ")V", null, null);
+		constructor.visitCode();
+
+		constructor.visitVarInsn(Opcodes.ALOAD, 0);
+		constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+
+		return constructor;
+	}
+
+	public void addVariable(Node variable) {
+		variablesInit.add(variable);
+	}
+}

--- a/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
+++ b/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
@@ -76,7 +76,12 @@ public class MemberAccessNode implements Node {
 		}
 
 		try {
-			Field f = klass.getField(name.getValue());
+			Field f = klass.getDeclaredField(name.getValue());
+
+			//TODO Protected
+			if(!Modifier.isPublic(f.getModifiers()) && !leftType.equals(Type.getObjectType(context.getCurrentClass()))) {
+				throw new NoSuchFieldException();
+			}
 
 			if(!isStaticAccess && Modifier.isStatic(f.getModifiers())) {
 				throw new SemanticException(name, "Cannot access static member from non-static object.");

--- a/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
+++ b/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
@@ -8,6 +8,7 @@ import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.LValue;
 import water.compiler.parser.Node;
+import water.compiler.parser.nodes.variable.VariableAccessNode;
 import water.compiler.util.TypeUtil;
 
 import java.lang.reflect.Field;
@@ -25,6 +26,7 @@ public class MemberAccessNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
+		if(left instanceof VariableAccessNode) ((VariableAccessNode) left).setMemberAccess(true);
 		Type leftType = left.getReturnType(context.getContext());
 
 		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length")) {
@@ -44,6 +46,7 @@ public class MemberAccessNode implements Node {
 
 	@Override
 	public Type getReturnType(Context context) throws SemanticException {
+		if(left instanceof VariableAccessNode) ((VariableAccessNode) left).setMemberAccess(true);
 		Type leftType = left.getReturnType(context);
 
 		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length")) return Type.INT_TYPE;

--- a/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
+++ b/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
@@ -13,21 +13,23 @@ import water.compiler.util.TypeUtil;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 public class MemberAccessNode implements Node {
 
 	private final Node left;
 	private final Token name;
+	private boolean isStaticAccess;
 
 	public MemberAccessNode(Node left, Token name) {
 		this.left = left;
 		this.name = name;
+		this.isStaticAccess = false;
 	}
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
-		if(left instanceof VariableAccessNode) ((VariableAccessNode) left).setMemberAccess(true);
-		Type leftType = left.getReturnType(context.getContext());
+		Type leftType = getLeftType(context.getContext());
 
 		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length")) {
 			left.visit(context);
@@ -46,12 +48,22 @@ public class MemberAccessNode implements Node {
 
 	@Override
 	public Type getReturnType(Context context) throws SemanticException {
-		if(left instanceof VariableAccessNode) ((VariableAccessNode) left).setMemberAccess(true);
-		Type leftType = left.getReturnType(context);
+		Type leftType = getLeftType(context);
 
 		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length")) return Type.INT_TYPE;
 
 		return resolve(leftType, context, false);
+	}
+
+	private Type getLeftType(Context context) throws SemanticException {
+		if(left instanceof VariableAccessNode) {
+			VariableAccessNode van = (VariableAccessNode) left;
+			van.setMemberAccess(true);
+			Type leftType = left.getReturnType(context);
+			isStaticAccess = van.isStaticClassAccess();
+			return  leftType;
+		}
+		return left.getReturnType(context);
 	}
 
 	private Type resolve(Type leftType, Context context, boolean generate) throws SemanticException {
@@ -65,6 +77,10 @@ public class MemberAccessNode implements Node {
 
 		try {
 			Field f = klass.getField(name.getValue());
+
+			if(!isStaticAccess && Modifier.isStatic(f.getModifiers())) {
+				throw new SemanticException(name, "Cannot access static member from non-static object.");
+			}
 
 			if(generate) {
 				context.getMethodVisitor().visitFieldInsn(TypeUtil.getAccessOpcode(f),
@@ -89,10 +105,14 @@ public class MemberAccessNode implements Node {
 		}
 	}
 
-	private Type attemptMethodCall(Class<?> klass, Type leftType, String methodName, boolean generate, Context context) throws NoSuchMethodException {
+	private Type attemptMethodCall(Class<?> klass, Type leftType, String methodName, boolean generate, Context context) throws NoSuchMethodException, SemanticException {
 		Method m = klass.getMethod(methodName);
 
 		Type returnType = Type.getType(m.getReturnType());
+
+		if(!isStaticAccess && Modifier.isStatic(m.getModifiers())) {
+			throw new SemanticException(name, "Cannot access static member from non-static object.");
+		}
 
 		if(generate) {
 			context.getMethodVisitor().visitMethodInsn(TypeUtil.getInvokeOpcode(m),

--- a/src/water/compiler/parser/nodes/classes/MethodCallNode.java
+++ b/src/water/compiler/parser/nodes/classes/MethodCallNode.java
@@ -7,6 +7,7 @@ import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
+import water.compiler.parser.nodes.variable.VariableAccessNode;
 import water.compiler.util.TypeUtil;
 import water.compiler.util.Unthrow;
 
@@ -30,6 +31,7 @@ public class MethodCallNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
+		if(left instanceof VariableAccessNode) ((VariableAccessNode) left).setMemberAccess(true);
 		Type leftType = left.getReturnType(context.getContext());
 
 		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length") && args.size() == 0) {
@@ -59,6 +61,7 @@ public class MethodCallNode implements Node {
 
 	@Override
 	public Type getReturnType(Context context) throws SemanticException {
+		if(left instanceof VariableAccessNode) ((VariableAccessNode) left).setMemberAccess(true);
 		Type leftType = left.getReturnType(context);
 
 		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length") && args.size() == 0) return Type.INT_TYPE;
@@ -84,7 +87,6 @@ public class MethodCallNode implements Node {
 			out:
 			for (Method method : klass.getMethods()) {
 				if(!method.getName().equals(name.getValue())) continue;
-
 				Type[] expectArgs = Type.getType(method).getArgumentTypes();
 
 				if (expectArgs.length != argTypes.length) continue;

--- a/src/water/compiler/parser/nodes/classes/MethodCallNode.java
+++ b/src/water/compiler/parser/nodes/classes/MethodCallNode.java
@@ -12,6 +12,7 @@ import water.compiler.util.TypeUtil;
 import water.compiler.util.Unthrow;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,17 +23,18 @@ public class MethodCallNode implements Node {
 	private final Node left;
 	private final Token name;
 	private final List<Node> args;
+	private boolean isStaticAccess;
 
 	public MethodCallNode(Node left, Token name, List<Node> args) {
 		this.left = left;
 		this.name = name;
 		this.args = args;
+		this.isStaticAccess = false;
 	}
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
-		if(left instanceof VariableAccessNode) ((VariableAccessNode) left).setMemberAccess(true);
-		Type leftType = left.getReturnType(context.getContext());
+		Type leftType = getLeftType(context.getContext());
 
 		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length") && args.size() == 0) {
 			left.visit(context);
@@ -61,12 +63,22 @@ public class MethodCallNode implements Node {
 
 	@Override
 	public Type getReturnType(Context context) throws SemanticException {
-		if(left instanceof VariableAccessNode) ((VariableAccessNode) left).setMemberAccess(true);
-		Type leftType = left.getReturnType(context);
+		Type leftType = getLeftType(context);
 
 		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length") && args.size() == 0) return Type.INT_TYPE;
 
 		return Type.getType(resolve(leftType, context).getReturnType());
+	}
+
+	private Type getLeftType(Context context) throws SemanticException {
+		if(left instanceof VariableAccessNode) {
+			VariableAccessNode van = (VariableAccessNode) left;
+			van.setMemberAccess(true);
+			Type leftType = left.getReturnType(context);
+			isStaticAccess = van.isStaticClassAccess();
+			return  leftType;
+		}
+		return left.getReturnType(context);
 	}
 
 	private Method resolve(Type leftType, Context context) throws SemanticException {
@@ -108,6 +120,18 @@ public class MethodCallNode implements Node {
 		catch(ClassNotFoundException e) {
 			throw new SemanticException(name, "Could not resolve class '%s'".formatted(e.getMessage()));
 		}
+
+		if(toCall == null) {
+			throw new SemanticException(name,
+					"Could not resolve method '%s' with arguments: %s".formatted(name.getValue(),
+							argTypes.length == 0 ? "(none)" :
+									List.of(argTypes).stream().map(TypeUtil::stringify).collect(Collectors.joining(", "))));
+		}
+
+		if(!isStaticAccess && Modifier.isStatic(toCall.getModifiers())) {
+			throw new SemanticException(name, "Cannot access static member from non-static object.");
+		}
+
 		return toCall;
 	}
 

--- a/src/water/compiler/parser/nodes/function/FunctionCallNode.java
+++ b/src/water/compiler/parser/nodes/function/FunctionCallNode.java
@@ -45,6 +45,8 @@ public class FunctionCallNode implements Node {
 
 			if(function.getFunctionType() == FunctionType.SOUT)
 				context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;");
+			else if(function.getFunctionType() == FunctionType.CLASS)
+				context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
 
 			for(Node n : args) n.visit(context);
 

--- a/src/water/compiler/parser/nodes/function/FunctionCallNode.java
+++ b/src/water/compiler/parser/nodes/function/FunctionCallNode.java
@@ -45,8 +45,10 @@ public class FunctionCallNode implements Node {
 
 			if(function.getFunctionType() == FunctionType.SOUT)
 				context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;");
-			else if(function.getFunctionType() == FunctionType.CLASS)
+			else if(function.getFunctionType() == FunctionType.CLASS) {
+				if(context.getContext().isStaticMethod()) throw new SemanticException(name, "Cannot invoke instance method '%s' from static context.".formatted(name.getValue()));
 				context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
+			}
 
 			for(Node n : args) n.visit(context);
 

--- a/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
@@ -165,7 +165,7 @@ public class FunctionDeclarationNode implements Node {
 
 	private MethodVisitor makeGlobalFunction(Context context) throws SemanticException {
 		int access = verifyAccess();
-		return context.getClassWriter().visitMethod(access | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL, name.getValue(), descriptor, null, null);
+		return context.getCurrentClassWriter().visitMethod(access | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL, name.getValue(), descriptor, null, null);
 	}
 
 	private void createMainMethod(Context context) throws SemanticException {
@@ -176,10 +176,10 @@ public class FunctionDeclarationNode implements Node {
 				|| returnType.getSort() != Type.VOID) // return void
 			return;
 
-		MethodVisitor mainMethodWithArgs = context.getClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC, "main", "([Ljava/lang/String;)V", null, null);
+		MethodVisitor mainMethodWithArgs = context.getCurrentClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC, "main", "([Ljava/lang/String;)V", null, null);
 
 		mainMethodWithArgs.visitCode();
-		mainMethodWithArgs.visitMethodInsn(Opcodes.INVOKESTATIC, context.getClassName(), "main", "()V", false);
+		mainMethodWithArgs.visitMethodInsn(Opcodes.INVOKESTATIC, context.getCurrentClass(), "main", "()V", false);
 		mainMethodWithArgs.visitInsn(Opcodes.RETURN);
 		mainMethodWithArgs.visitMaxs(0, 0);
 		mainMethodWithArgs.visitEnd();

--- a/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
@@ -128,6 +128,8 @@ public class FunctionDeclarationNode implements Node {
 
 		context.getContext().getScope().setReturnType(returnType);
 
+		context.getContext().setStaticMethod(isStatic(context.getContext()));
+
 		addParameters(context.getContext(), isStatic(context.getContext()));
 
 		body.visit(context);

--- a/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -6,6 +6,7 @@ import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
+import water.compiler.util.TypeUtil;
 
 public class TypeNode implements Node {
 	private final Token root;
@@ -53,9 +54,7 @@ public class TypeNode implements Node {
 		};
 
 		try {
-			if(context.getImports().get(path) != null) return Type.getType(Class.forName(context.getImports().get(path), false, context.getLoader()));
-
-			return Type.getType(Class.forName(path, false, context.getLoader()));
+			return Type.getType(TypeUtil.classForName(path, context));
 		} catch (ClassNotFoundException e) {
 			throw new SemanticException(root, "Could not resolve class '%s'".formatted(e.getMessage()));
 		}

--- a/src/water/compiler/parser/nodes/variable/AssignmentNode.java
+++ b/src/water/compiler/parser/nodes/variable/AssignmentNode.java
@@ -82,7 +82,7 @@ public class AssignmentNode implements Node {
 		MethodVisitor methodVisitor = context.getContext().getMethodVisitor();
 		if(!isExpressionStatementBody) methodVisitor.visitInsn(TypeUtil.getDupOpcode(returnType));
 
-		if(variable.getVariableType() == VariableType.GLOBAL) {
+		if(variable.getVariableType() == VariableType.STATIC) {
 			methodVisitor.visitFieldInsn(Opcodes.PUTSTATIC, variable.getOwner(), variable.getName(), variable.getType().getDescriptor());
 		}
 		else {

--- a/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
@@ -15,10 +15,12 @@ import water.compiler.util.TypeUtil;
 public class VariableAccessNode implements Node {
 	private final Token name;
 	private boolean isMemberAccess;
+	private boolean isStaticClassAccess;
 
 	public VariableAccessNode(Token name) {
 		this.name = name;
 		this.isMemberAccess = false;
+		this.isStaticClassAccess = false;
 	}
 
 	@Override
@@ -30,6 +32,7 @@ public class VariableAccessNode implements Node {
 			if(isMemberAccess) {
 				try {
 					TypeUtil.classForName(name.getValue(), context.getContext());
+					isStaticClassAccess = true;
 					return;
 				} catch (ClassNotFoundException e) {
 					throw new SemanticException(name, "Cannot resolve variable '%s' in current scope.".formatted(name.getValue()));
@@ -59,6 +62,7 @@ public class VariableAccessNode implements Node {
 			if(isMemberAccess) {
 				try {
 					Class<?> staticClass = TypeUtil.classForName(name.getValue(), context);
+					isStaticClassAccess = true;
 					return Type.getType(staticClass);
 				} catch (ClassNotFoundException e) {
 					throw new SemanticException(name, "Cannot resolve variable '%s' in current scope.".formatted(name.getValue()));
@@ -82,6 +86,10 @@ public class VariableAccessNode implements Node {
 
 	public void setMemberAccess(boolean memberAccess) {
 		isMemberAccess = memberAccess;
+	}
+
+	public boolean isStaticClassAccess() {
+		return isStaticClassAccess;
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
@@ -41,6 +41,10 @@ public class VariableAccessNode implements Node {
 		if(v.getVariableType() == VariableType.GLOBAL) {
 			context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.GETSTATIC, v.getOwner(), v.getName(), v.getType().getDescriptor());
 		}
+		else if(v.getVariableType() == VariableType.CLASS) {
+			context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
+			context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.GETFIELD, v.getOwner(), v.getName(), v.getType().getDescriptor());
+		}
 		else {
 			context.getContext().getMethodVisitor().visitVarInsn(v.getType().getOpcode(Opcodes.ILOAD), v.getIndex());
 		}

--- a/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
@@ -42,6 +42,7 @@ public class VariableAccessNode implements Node {
 			context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.GETSTATIC, v.getOwner(), v.getName(), v.getType().getDescriptor());
 		}
 		else if(v.getVariableType() == VariableType.CLASS) {
+			if(context.getContext().isStaticMethod())  throw new SemanticException(name, "Cannot access instance member '%s' in a static context".formatted(name.getValue()));
 			context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
 			context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.GETFIELD, v.getOwner(), v.getName(), v.getType().getDescriptor());
 		}

--- a/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
@@ -38,7 +38,7 @@ public class VariableAccessNode implements Node {
 			throw new SemanticException(name, "Cannot resolve variable '%s' in current scope.".formatted(name.getValue()));
 		}
 
-		if(v.getVariableType() == VariableType.GLOBAL) {
+		if(v.getVariableType() == VariableType.STATIC) {
 			context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.GETSTATIC, v.getOwner(), v.getName(), v.getType().getDescriptor());
 		}
 		else if(v.getVariableType() == VariableType.CLASS) {

--- a/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
@@ -81,8 +81,14 @@ public class VariableDeclarationNode implements Node {
 		else if(context.getContext().getType() == ContextType.CLASS) {
 			defineGetAndSet(false, isStatic(context.getContext()), context.getContext());
 
-			context.getContext().setMethodVisitor(context.getContext().getDefaultConstructor());
-			if(!isStatic(context.getContext())) context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
+			if(isStatic(context.getContext())) {
+				context.getContext().setMethodVisitor(context.getContext().getStaticMethodVisitor());
+			}
+			else {
+				context.getContext().setMethodVisitor(context.getContext().getDefaultConstructor());
+				context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
+			}
+
 			value.visit(context);
 
 			int setOpcode = isStatic(context.getContext()) ? Opcodes.PUTSTATIC : Opcodes.PUTFIELD;
@@ -142,7 +148,7 @@ public class VariableDeclarationNode implements Node {
 		};
 	}
 
-	private boolean isStatic(Context context) {
+	public boolean isStatic(Context context) {
 		return staticModifier != null || context.getType() == ContextType.GLOBAL;
 	}
 

--- a/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
@@ -51,7 +51,7 @@ public class VariableDeclarationNode implements Node {
 		boolean buildConstructor = context.getContext().getConstructors().size() != 0;
 
 		if(context.getContext().getType() == ContextType.GLOBAL) {
-			if(!buildConstructor) defineGetAndSet(true, true, context.getContext());
+			defineGetAndSet(true, true, context.getContext());
 
 			context.getContext().setMethodVisitor(context.getContext().getStaticMethodVisitor());
 			context.getContext().setStaticMethod(true);

--- a/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
@@ -83,7 +83,7 @@ public class VariableDeclarationNode implements Node {
 		// Getter
 		if(verifyAccess()) {
 			String fName = name.getValue().matches("^is[\\p{Lu}].*") ? name.getValue() : "get" + beanName;
-			MethodVisitor visitor = context.getCurrentClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC, fName, "()" + descriptor, null, null);
+			MethodVisitor visitor = context.getCurrentClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL, fName, "()" + descriptor, null, null);
 			visitor.visitCode();
 			visitor.visitFieldInsn(Opcodes.GETSTATIC, context.getCurrentClass(), name.getValue(), descriptor);
 			visitor.visitInsn(fieldType.getOpcode(Opcodes.IRETURN));
@@ -93,7 +93,7 @@ public class VariableDeclarationNode implements Node {
 		//Setter
 		if(verifyAccess() && !isConst) {
 			String fName = "set" + (name.getValue().matches("^is[\\p{Lu}].*") ? beanName.substring(2) : beanName);
-			MethodVisitor visitor = context.getCurrentClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC, fName, "("  + descriptor + ")V", null, null);
+			MethodVisitor visitor = context.getCurrentClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL, fName, "("  + descriptor + ")V", null, null);
 			visitor.visitCode();
 			visitor.visitVarInsn(fieldType.getOpcode(Opcodes.ILOAD), 0);
 			visitor.visitFieldInsn(Opcodes.PUTSTATIC, context.getCurrentClass(), name.getValue(), descriptor);

--- a/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
@@ -44,7 +44,7 @@ public class VariableDeclarationNode implements Node {
 			context.getContext().setMethodVisitor(context.getContext().getStaticMethodVisitor());
 			value.visit(context);
 
-			context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.PUTSTATIC, Type.getInternalName(context.getKlass()), name.getValue(), returnType.getDescriptor());
+			context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.PUTSTATIC, Type.getInternalName(context.getCurrentClass()), name.getValue(), returnType.getDescriptor());
 		}
 		else if(context.getContext().getType() == ContextType.FUNCTION) {
 
@@ -73,7 +73,7 @@ public class VariableDeclarationNode implements Node {
 
 		int finalMod = isConst ? Opcodes.ACC_FINAL : 0;
 
-		context.getClassWriter().visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | finalMod, name.getValue(), value.getReturnType(context).getDescriptor(), null, null);
+		context.getCurrentClassWriter().visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | finalMod, name.getValue(), value.getReturnType(context).getDescriptor(), null, null);
 
 		String beanName = name.getValue().substring(0, 1).toUpperCase() + name.getValue().substring(1);
 
@@ -83,9 +83,9 @@ public class VariableDeclarationNode implements Node {
 		// Getter
 		if(verifyAccess()) {
 			String fName = name.getValue().matches("^is[\\p{Lu}].*") ? name.getValue() : "get" + beanName;
-			MethodVisitor visitor = context.getClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC, fName, "()" + descriptor, null, null);
+			MethodVisitor visitor = context.getCurrentClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC, fName, "()" + descriptor, null, null);
 			visitor.visitCode();
-			visitor.visitFieldInsn(Opcodes.GETSTATIC, context.getClassName(), name.getValue(), descriptor);
+			visitor.visitFieldInsn(Opcodes.GETSTATIC, context.getCurrentClass(), name.getValue(), descriptor);
 			visitor.visitInsn(fieldType.getOpcode(Opcodes.IRETURN));
 			visitor.visitMaxs(1, 0);
 			visitor.visitEnd();
@@ -93,10 +93,10 @@ public class VariableDeclarationNode implements Node {
 		//Setter
 		if(verifyAccess() && !isConst) {
 			String fName = "set" + (name.getValue().matches("^is[\\p{Lu}].*") ? beanName.substring(2) : beanName);
-			MethodVisitor visitor = context.getClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC, fName, "("  + descriptor + ")V", null, null);
+			MethodVisitor visitor = context.getCurrentClassWriter().visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC, fName, "("  + descriptor + ")V", null, null);
 			visitor.visitCode();
 			visitor.visitVarInsn(fieldType.getOpcode(Opcodes.ILOAD), 0);
-			visitor.visitFieldInsn(Opcodes.PUTSTATIC, context.getClassName(), name.getValue(), descriptor);
+			visitor.visitFieldInsn(Opcodes.PUTSTATIC, context.getCurrentClass(), name.getValue(), descriptor);
 			visitor.visitInsn(Opcodes.RETURN);
 			visitor.visitMaxs(1, 1);
 			visitor.visitEnd();

--- a/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
@@ -54,6 +54,7 @@ public class VariableDeclarationNode implements Node {
 			defineGetAndSet(true, true, context.getContext());
 
 			context.getContext().setMethodVisitor(context.getContext().getStaticMethodVisitor());
+			context.getContext().setStaticMethod(true);
 			value.visit(context);
 
 			context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.PUTSTATIC, Type.getInternalName(context.getCurrentClass()), name.getValue(), returnType.getDescriptor());
@@ -83,10 +84,12 @@ public class VariableDeclarationNode implements Node {
 
 			if(isStatic(context.getContext())) {
 				context.getContext().setMethodVisitor(context.getContext().getStaticMethodVisitor());
+				context.getContext().setStaticMethod(true);
 			}
 			else {
 				context.getContext().setMethodVisitor(context.getContext().getDefaultConstructor());
 				context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
+				context.getContext().setStaticMethod(false);
 			}
 
 			value.visit(context);

--- a/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
@@ -14,12 +14,14 @@ public class VariableDeclarationNode implements Node {
 	private final Node value;
 	private final boolean isConst;
 	private final Token access;
+	private final Token staticModifier;
 
-	public VariableDeclarationNode(Token name, Node value, boolean isConst, Token access) {
+	public VariableDeclarationNode(Token name, Node value, boolean isConst, Token access, Token staticModifier) {
 		this.name = name;
 		this.value = value;
 		this.isConst = isConst;
 		this.access = access;
+		this.staticModifier = staticModifier;
 	}
 
 	@Override

--- a/src/water/compiler/util/TypeUtil.java
+++ b/src/water/compiler/util/TypeUtil.java
@@ -20,6 +20,8 @@ public class TypeUtil {
 	private static final List<Integer> TYPE_SIZE = List.of(Type.DOUBLE, Type.FLOAT, Type.LONG, Type.INT, Type.SHORT, Type.CHAR, Type.BYTE);
 	/** A constant defining a Type representing the java.lang.String class */
 	public static final Type STRING_TYPE = Type.getObjectType("java/lang/String");
+	/** A constant defining a Type representing the java.lang.Object class */
+	public static final Type OBJECT_TYPE = Type.getObjectType("java/lang/Object");
 
 	/** Returns the correct opcode given a type. */
 	public static int getPopOpcode(Type type) {

--- a/src/water/compiler/util/TypeUtil.java
+++ b/src/water/compiler/util/TypeUtil.java
@@ -455,6 +455,21 @@ public class TypeUtil {
 		};
 	}
 
+	/**
+	 * Looks up a class for the given name, using imports to resolve.
+	 * @param name The name of the class
+	 * @param context The context to use for the {@link water.compiler.WaterClassLoader} and imports
+	 * @return The resolved Class
+	 * @throws ClassNotFoundException If the class cannot be resolved
+	 */
+	public static Class<?> classForName(String name, Context context) throws ClassNotFoundException {
+		String className = name;
+
+		if(context.getImports().get(name) != null) className = context.getImports().get(name);
+
+		return Class.forName(className, false, context.getLoader());
+	}
+
 	/*
 	 Copyright Notice for use of ASM code (if link dies):
 


### PR DESCRIPTION
Class definitions follow this form:

```
<access> class <name> {
    <declarations>
}
````
Where declarations may be a variable/constant, method (using `function`), or a constructor. These may, alongside standard access modifiers, be marked as `static`.

Multiple classes may be defined per file, alongside other top-level declarations. 

A constructor takes the form of:
```
<access> constructor(<params>) { <body> }
```
Since superclasses are not currently supported, all constructors implicitally call `Object.<init>()`
