### PR TITLE
Function Parameter Resolve

### DIFF
--- a/src/water/compiler/Main.java
+++ b/src/water/compiler/Main.java
@@ -138,7 +138,6 @@ public class Main {
 			try {
 				fc.getAst().visit(fc);
 			} catch (SemanticException e) {
-				e.printStackTrace();
 				error(-2, e.getErrorMessage(fc.getPath().toString()));
 			}
 

--- a/src/water/compiler/parser/nodes/function/FunctionCallNode.java
+++ b/src/water/compiler/parser/nodes/function/FunctionCallNode.java
@@ -50,7 +50,8 @@ public class FunctionCallNode implements Node {
 				context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
 			}
 
-			for(Node n : args) n.visit(context);
+			// Build args with lookupFunction
+			context.getContext().getScope().lookupFunction(name.getValue(), argTypes, args.toArray(Node[]::new), true, context);
 
 			context.getContext().getMethodVisitor().visitMethodInsn(function.getAccess(), function.getOwner(), function.getName(), function.getType().getDescriptor(), false);
 

--- a/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
@@ -120,6 +120,8 @@ public class FunctionDeclarationNode implements Node {
 
 		ContextType prev = context.getContext().getType();
 
+		boolean isStatic = isStatic(context.getContext());
+
 		context.getContext().setType(ContextType.FUNCTION);
 
 		Scope outer = context.getContext().getScope();
@@ -128,9 +130,10 @@ public class FunctionDeclarationNode implements Node {
 
 		context.getContext().getScope().setReturnType(returnType);
 
-		context.getContext().setStaticMethod(isStatic(context.getContext()));
 
-		addParameters(context.getContext(), isStatic(context.getContext()));
+		context.getContext().setStaticMethod(isStatic);
+
+		addParameters(context.getContext(), isStatic);
 
 		body.visit(context);
 		if(type == DeclarationType.EXPRESSION) mv.visitInsn(returnType.getOpcode(Opcodes.IRETURN));

--- a/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
@@ -57,7 +57,7 @@ public class FunctionDeclarationNode implements Node {
 
 	private void preprocessGlobal(Context context) throws SemanticException {
 		try {
-			if (context.getScope().lookupFunction(name.getValue(), parameters.stream().map(n -> Unthrow.wrap(() -> n.getSecond().getReturnType(context))).toArray(Type[]::new)) != null) throw new SemanticException(name,
+			if (context.getScope().exactLookupFunction(name.getValue(), parameters.stream().map(n -> Unthrow.wrap(() -> n.getSecond().getReturnType(context))).toArray(Type[]::new)) != null) throw new SemanticException(name,
 					"Redefinition of function '%s' in global scope.".formatted(name.getValue()));
 
 			computeReturnType(context, true);


### PR DESCRIPTION
These changes allow for functions/methods/constructors to cast their arguments to match definitions. For example:
```
function x(y: double) = y * 2.5;

function main() {
	println(x(12)); // 12 is an integer which needs to be cast to a double
}
```