### PR TITLE
Support for All Primitives

### DIFF
--- a/src/water/compiler/compiler/Scope.java
+++ b/src/water/compiler/compiler/Scope.java
@@ -39,6 +39,7 @@ public class Scope {
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(D)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(I)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(Z)V")));
+		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(C)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(Ljava/lang/Object;)V")));
 
 		updateCurrentClassMethods(context);

--- a/src/water/compiler/compiler/Scope.java
+++ b/src/water/compiler/compiler/Scope.java
@@ -41,6 +41,7 @@ public class Scope {
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(I)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(Z)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(C)V")));
+		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(J)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(Ljava/lang/Object;)V")));
 
 		updateCurrentClassMethods(context);

--- a/src/water/compiler/compiler/Scope.java
+++ b/src/water/compiler/compiler/Scope.java
@@ -37,6 +37,7 @@ public class Scope {
 
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("()V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(D)V")));
+		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(F)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(I)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(Z)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", Type.getMethodType("(C)V")));

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -11,7 +11,7 @@ public class Lexer {
 
 	//TODO Other primitives
 	/** TokenTypes which represent keywords for primitives, e.g. 'int' */
-	public static List<TokenType> PRIMITIVE_TYPES = List.of(TokenType.INT, TokenType.DOUBLE, TokenType.BOOLEAN);
+	public static List<TokenType> PRIMITIVE_TYPES = List.of(TokenType.INT, TokenType.DOUBLE, TokenType.BOOLEAN, TokenType.CHAR);
 
 	private int index;
 	private int line;
@@ -68,6 +68,9 @@ public class Lexer {
 			else if(current == '"') {
 				token = string();
 			}
+			else if(current == '\'') {
+				token = character();
+			}
 			else {
 				TokenType type = switch (current) {
 					case '{' -> TokenType.LBRACE;
@@ -116,6 +119,19 @@ public class Lexer {
 	}
 
 	/**
+	 * Consumes a character literal
+	 * @return The character token, or error
+	 */
+	private Token character() {
+		advance();
+
+		// The character
+		advance();
+		TokenType type = current == '\'' ? TokenType.CHAR_LITERAL : TokenType.ERROR;
+		return makeToken(TokenType.CHAR_LITERAL);
+	}
+
+	/**
 	 * Consumes a single identifier, returning a token with a type of either IDENTIFIER or the corresponding keyword.
 	 * A identifier is valid if it starts with {@link #isValidIdentifierStart(char)}
 	 * and all following chars are correct, as defined by {@link #isValidIdentifierPart(char)}
@@ -150,6 +166,7 @@ public class Lexer {
 			case "int" -> TokenType.INT;
 			case "double" -> TokenType.DOUBLE;
 			case "boolean" -> TokenType.BOOLEAN;
+			case "char" -> TokenType.CHAR;
 			case "public" -> TokenType.PUBLIC;
 			case "private" -> TokenType.PRIVATE;
 			case "static" -> TokenType.STATIC;

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -11,7 +11,7 @@ public class Lexer {
 
 	//TODO Other primitives
 	/** TokenTypes which represent keywords for primitives, e.g. 'int' */
-	public static List<TokenType> PRIMITIVE_TYPES = List.of(TokenType.INT, TokenType.DOUBLE, TokenType.BOOLEAN, TokenType.CHAR);
+	public static List<TokenType> PRIMITIVE_TYPES = List.of(TokenType.INT, TokenType.DOUBLE, TokenType.FLOAT, TokenType.BOOLEAN, TokenType.CHAR);
 
 	private int index;
 	private int line;
@@ -165,6 +165,7 @@ public class Lexer {
 			case "void" -> TokenType.VOID;
 			case "int" -> TokenType.INT;
 			case "double" -> TokenType.DOUBLE;
+			case "float" -> TokenType.FLOAT;
 			case "boolean" -> TokenType.BOOLEAN;
 			case "char" -> TokenType.CHAR;
 			case "public" -> TokenType.PUBLIC;
@@ -175,7 +176,7 @@ public class Lexer {
 	}
 
 	/**
-	 * Consumes a number, in form (regex): [0-9]+(\.[0-9]+)?
+	 * Consumes a number, in form (regex): [0-9]+(\.[0-9]+)?f?
 	 * @return The consumed token
 	 */
 	private Token number() {
@@ -190,6 +191,7 @@ public class Lexer {
 			}
 			if(!isAtEnd()) index--;
 		}
+		if(current == 'f' || current == 'F') advance();
 		return makeToken(TokenType.NUMBER);
 	}
 

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -11,7 +11,8 @@ public class Lexer {
 
 	//TODO Other primitives
 	/** TokenTypes which represent keywords for primitives, e.g. 'int' */
-	public static List<TokenType> PRIMITIVE_TYPES = List.of(TokenType.INT, TokenType.DOUBLE, TokenType.FLOAT, TokenType.BOOLEAN, TokenType.CHAR, TokenType.LONG);
+	public static List<TokenType> PRIMITIVE_TYPES = List.of(TokenType.INT, TokenType.DOUBLE,
+			TokenType.FLOAT, TokenType.BOOLEAN, TokenType.CHAR, TokenType.LONG, TokenType.BYTE);
 
 	private int index;
 	private int line;
@@ -169,6 +170,7 @@ public class Lexer {
 			case "boolean" -> TokenType.BOOLEAN;
 			case "char" -> TokenType.CHAR;
 			case "long" -> TokenType.LONG;
+			case "byte" -> TokenType.BYTE;
 			case "public" -> TokenType.PUBLIC;
 			case "private" -> TokenType.PRIVATE;
 			case "static" -> TokenType.STATIC;

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -9,10 +9,9 @@ import java.util.List;
  */
 public class Lexer {
 
-	//TODO Other primitives
 	/** TokenTypes which represent keywords for primitives, e.g. 'int' */
 	public static List<TokenType> PRIMITIVE_TYPES = List.of(TokenType.INT, TokenType.DOUBLE,
-			TokenType.FLOAT, TokenType.BOOLEAN, TokenType.CHAR, TokenType.LONG, TokenType.BYTE);
+			TokenType.FLOAT, TokenType.BOOLEAN, TokenType.CHAR, TokenType.LONG, TokenType.BYTE, TokenType.SHORT);
 
 	private int index;
 	private int line;
@@ -171,6 +170,7 @@ public class Lexer {
 			case "char" -> TokenType.CHAR;
 			case "long" -> TokenType.LONG;
 			case "byte" -> TokenType.BYTE;
+			case "short" -> TokenType.SHORT;
 			case "public" -> TokenType.PUBLIC;
 			case "private" -> TokenType.PRIVATE;
 			case "static" -> TokenType.STATIC;

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -11,7 +11,7 @@ public class Lexer {
 
 	//TODO Other primitives
 	/** TokenTypes which represent keywords for primitives, e.g. 'int' */
-	public static List<TokenType> PRIMITIVE_TYPES = List.of(TokenType.INT, TokenType.DOUBLE, TokenType.FLOAT, TokenType.BOOLEAN, TokenType.CHAR);
+	public static List<TokenType> PRIMITIVE_TYPES = List.of(TokenType.INT, TokenType.DOUBLE, TokenType.FLOAT, TokenType.BOOLEAN, TokenType.CHAR, TokenType.LONG);
 
 	private int index;
 	private int line;
@@ -168,6 +168,7 @@ public class Lexer {
 			case "float" -> TokenType.FLOAT;
 			case "boolean" -> TokenType.BOOLEAN;
 			case "char" -> TokenType.CHAR;
+			case "long" -> TokenType.LONG;
 			case "public" -> TokenType.PUBLIC;
 			case "private" -> TokenType.PRIVATE;
 			case "static" -> TokenType.STATIC;
@@ -184,6 +185,10 @@ public class Lexer {
 			advance();
 		}
 		if(!isAtEnd()) index--;
+		if(current == 'l' || current == 'L') {
+			advance();
+			return makeToken(TokenType.NUMBER);
+		}
 		if(match('.')) {
 			advance();
 			while (!isAtEnd() && isNumeric(current)) {

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -49,6 +49,7 @@ public enum TokenType {
 	FLOAT,
 	LONG,
 	BYTE,
+	SHORT,
 	PUBLIC,
 	PRIVATE,
 	STATIC,

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -46,6 +46,7 @@ public enum TokenType {
 	DOUBLE,
 	BOOLEAN,
 	CHAR,
+	FLOAT,
 	PUBLIC,
 	PRIVATE,
 	STATIC,

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -48,6 +48,7 @@ public enum TokenType {
 	CHAR,
 	FLOAT,
 	LONG,
+	BYTE,
 	PUBLIC,
 	PRIVATE,
 	STATIC,

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -45,6 +45,7 @@ public enum TokenType {
 	INT,
 	DOUBLE,
 	BOOLEAN,
+	CHAR,
 	PUBLIC,
 	PRIVATE,
 	STATIC,
@@ -52,6 +53,7 @@ public enum TokenType {
 	// Literals
 	NUMBER,
 	STRING,
+	CHAR_LITERAL,
 
 	// Special
 	ERROR,

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -47,6 +47,7 @@ public enum TokenType {
 	BOOLEAN,
 	CHAR,
 	FLOAT,
+	LONG,
 	PUBLIC,
 	PRIVATE,
 	STATIC,

--- a/src/water/compiler/parser/Parser.java
+++ b/src/water/compiler/parser/Parser.java
@@ -460,12 +460,13 @@ public class Parser {
 		return left;
 	}
 
-	/** Forms grammar: NUMBER | STRING | 'true' | 'false' | 'null' | newObject | grouping | variable */
+	/** Forms grammar: NUMBER | STRING | CHAR_LITERAL | 'true' | 'false' | 'null' | newObject | grouping | variable */
 	private Node atom() throws UnexpectedTokenException {
 		Token tok = advance();
 		return switch(tok.getType()) {
 			case NUMBER -> new NumberNode(tok);
 			case STRING -> new StringNode(tok);
+			case CHAR_LITERAL -> new CharNode(tok);
 			case TRUE, FALSE -> new BooleanNode(tok);
 			case NULL -> new NullNode();
 			case NEW -> newObject();

--- a/src/water/compiler/parser/nodes/classes/MethodCallNode.java
+++ b/src/water/compiler/parser/nodes/classes/MethodCallNode.java
@@ -158,7 +158,7 @@ public class MethodCallNode implements Node {
 				throw new SemanticException(name, "Cannot invoke static method from non-static object.");
 		}
 
-		return possible.get(0).getSecond();
+		return appliedPossible.get(0).getSecond();
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
@@ -86,7 +86,7 @@ public class FunctionDeclarationNode implements Node {
 	private void preprocessClass(Context context) throws SemanticException {
 		try {
 			// Verify this function is unique
-			Function function = context.getScope().lookupFunction(name.getValue(), parameters.stream().map(n -> Unthrow.wrap(() -> n.getSecond().getReturnType(context))).toArray(Type[]::new));
+			Function function = context.getScope().exactLookupFunction(name.getValue(), parameters.stream().map(n -> Unthrow.wrap(() -> n.getSecond().getReturnType(context))).toArray(Type[]::new));
 
 			if(function != null && function.getFunctionType() == FunctionType.CLASS) {
 				throw new SemanticException(name, "Redefinition of function '%s' in current class.".formatted(name.getValue()));

--- a/src/water/compiler/parser/nodes/operation/ArithmeticOperationNode.java
+++ b/src/water/compiler/parser/nodes/operation/ArithmeticOperationNode.java
@@ -12,6 +12,8 @@ import water.compiler.lexer.TokenType;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
 
+import java.util.List;
+
 public class ArithmeticOperationNode implements Node {
 
 	private final Node left;
@@ -192,7 +194,12 @@ public class ArithmeticOperationNode implements Node {
 
 	@Override
 	public boolean isConstant(Context context) throws SemanticException {
-		if((left.getReturnType(context).equals(TypeUtil.STRING_TYPE) || right.getReturnType(context).equals(TypeUtil.STRING_TYPE)) && op.getType() == TokenType.STAR) return false;
+		List<Class<?>> shouldBeConstant = List.of(String.class, Integer.class, Double.class);
+		Object leftReturnType = left.getReturnType(context);
+		Type rightReturnType = right.getReturnType(context);
+
+		if(!shouldBeConstant.contains(leftReturnType.getClass()) || !shouldBeConstant.contains(rightReturnType.getClass())) return false;
+		if((leftReturnType.equals(TypeUtil.STRING_TYPE) || rightReturnType.equals(TypeUtil.STRING_TYPE)) && op.getType() == TokenType.STAR) return false;
 		return left.isConstant(context) && right.isConstant(context);
 	}
 

--- a/src/water/compiler/parser/nodes/value/CharNode.java
+++ b/src/water/compiler/parser/nodes/value/CharNode.java
@@ -1,0 +1,48 @@
+package water.compiler.parser.nodes.value;
+
+import org.objectweb.asm.Type;
+import water.compiler.FileContext;
+import water.compiler.compiler.Context;
+import water.compiler.compiler.SemanticException;
+import water.compiler.lexer.Token;
+import water.compiler.parser.Node;
+import water.compiler.util.TypeUtil;
+
+public class CharNode implements Node {
+
+	private final Token value;
+
+	public CharNode(Token value) {
+		this.value = value;
+	}
+
+	@Override
+	public void visit(FileContext context) throws SemanticException {
+		context.getContext().updateLine(value.getLine());
+
+		// Remove double quotes
+		char val = value.getValue().charAt(1);
+
+		TypeUtil.generateCorrectInt(val, context.getContext());
+	}
+
+	@Override
+	public Type getReturnType(Context context) throws SemanticException {
+		return Type.CHAR_TYPE;
+	}
+
+	@Override
+	public Object getConstantValue(Context context) {
+		return value.getValue().charAt(1);
+	}
+
+	@Override
+	public boolean isConstant(Context context) throws SemanticException {
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return value.getValue();
+	}
+}

--- a/src/water/compiler/parser/nodes/value/NullNode.java
+++ b/src/water/compiler/parser/nodes/value/NullNode.java
@@ -6,6 +6,7 @@ import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.parser.Node;
+import water.compiler.util.TypeUtil;
 
 public class NullNode implements Node {
 	@Override
@@ -15,7 +16,7 @@ public class NullNode implements Node {
 
 	@Override
 	public Type getReturnType(Context context) throws SemanticException {
-		return Type.getObjectType("java/lang/Object");
+		return TypeUtil.OBJECT_TYPE;
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/value/NumberNode.java
+++ b/src/water/compiler/parser/nodes/value/NumberNode.java
@@ -32,6 +32,9 @@ public class NumberNode implements Node {
 		else if(type.getSort() == Type.DOUBLE) {
 			TypeUtil.generateCorrectDouble(Double.parseDouble(value.getValue()), context.getContext());
 		}
+		else if(type.getSort() == Type.FLOAT) {
+			TypeUtil.generateCorrectFloat(Float.parseFloat(value.getValue()), context.getContext());
+		}
 	}
 
 	@Override
@@ -43,6 +46,7 @@ public class NumberNode implements Node {
 	public Object getConstantValue(Context context) {
 		if(type.getSort() == Type.INT) return Integer.parseInt(value.getValue());
 		else if(type.getSort() == Type.DOUBLE) return Double.parseDouble(value.getValue());
+		else if(type.getSort() == Type.FLOAT) return Float.parseFloat(value.getValue());
 
 		return null; // Unreachable
 	}
@@ -55,6 +59,7 @@ public class NumberNode implements Node {
 	private Type computeCorrectType() {
 		String rep = value.getValue();
 
+		if(rep.endsWith("f") || rep.endsWith("F")) return Type.FLOAT_TYPE;
 		if(rep.contains(".")) return Type.DOUBLE_TYPE;
 		return Type.INT_TYPE;
 	}

--- a/src/water/compiler/parser/nodes/value/NumberNode.java
+++ b/src/water/compiler/parser/nodes/value/NumberNode.java
@@ -35,6 +35,9 @@ public class NumberNode implements Node {
 		else if(type.getSort() == Type.FLOAT) {
 			TypeUtil.generateCorrectFloat(Float.parseFloat(value.getValue()), context.getContext());
 		}
+		else if(type.getSort() == Type.LONG) {
+			TypeUtil.generateCorrectLong(Long.parseLong(value.getValue().substring(0, value.getValue().length() - 1)), context.getContext());
+		}
 	}
 
 	@Override
@@ -47,6 +50,7 @@ public class NumberNode implements Node {
 		if(type.getSort() == Type.INT) return Integer.parseInt(value.getValue());
 		else if(type.getSort() == Type.DOUBLE) return Double.parseDouble(value.getValue());
 		else if(type.getSort() == Type.FLOAT) return Float.parseFloat(value.getValue());
+		else if(type.getSort() == Type.LONG) return Long.parseLong(value.getValue().substring(0, value.getValue().length() - 1));
 
 		return null; // Unreachable
 	}
@@ -59,6 +63,7 @@ public class NumberNode implements Node {
 	private Type computeCorrectType() {
 		String rep = value.getValue();
 
+		if(rep.endsWith("l") || rep.endsWith("L")) return Type.LONG_TYPE;
 		if(rep.endsWith("f") || rep.endsWith("F")) return Type.FLOAT_TYPE;
 		if(rep.contains(".")) return Type.DOUBLE_TYPE;
 		return Type.INT_TYPE;

--- a/src/water/compiler/parser/nodes/value/StringNode.java
+++ b/src/water/compiler/parser/nodes/value/StringNode.java
@@ -6,6 +6,7 @@ import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
+import water.compiler.util.TypeUtil;
 
 public class StringNode implements Node {
 	private final Token value;
@@ -25,7 +26,7 @@ public class StringNode implements Node {
 
 	@Override
 	public Type getReturnType(Context context) throws SemanticException {
-		return Type.getObjectType("java/lang/String");
+		return TypeUtil.STRING_TYPE;
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -50,6 +50,7 @@ public class TypeNode implements Node {
 			case INT -> Type.INT_TYPE;
 			case DOUBLE -> Type.DOUBLE_TYPE;
 			case BOOLEAN -> Type.BOOLEAN_TYPE;
+			case CHAR -> Type.CHAR_TYPE;
 			default -> null;
 		};
 

--- a/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -52,6 +52,7 @@ public class TypeNode implements Node {
 			case FLOAT -> Type.FLOAT_TYPE;
 			case BOOLEAN -> Type.BOOLEAN_TYPE;
 			case CHAR -> Type.CHAR_TYPE;
+			case LONG -> Type.LONG_TYPE;
 			default -> null;
 		};
 

--- a/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -44,7 +44,6 @@ public class TypeNode implements Node {
 
 		if(dimensions != 0) return Type.getType("[".repeat(dimensions) + element.getReturnType(context).getDescriptor());
 
-		//TODO other primitive types
 		if(isPrimitive) return switch (root.getType()) {
 			case VOID -> Type.VOID_TYPE;
 			case INT -> Type.INT_TYPE;
@@ -54,6 +53,7 @@ public class TypeNode implements Node {
 			case CHAR -> Type.CHAR_TYPE;
 			case LONG -> Type.LONG_TYPE;
 			case BYTE -> Type.BYTE_TYPE;
+			case SHORT -> Type.SHORT_TYPE;
 			default -> null;
 		};
 

--- a/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -53,6 +53,7 @@ public class TypeNode implements Node {
 			case BOOLEAN -> Type.BOOLEAN_TYPE;
 			case CHAR -> Type.CHAR_TYPE;
 			case LONG -> Type.LONG_TYPE;
+			case BYTE -> Type.BYTE_TYPE;
 			default -> null;
 		};
 

--- a/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -49,6 +49,7 @@ public class TypeNode implements Node {
 			case VOID -> Type.VOID_TYPE;
 			case INT -> Type.INT_TYPE;
 			case DOUBLE -> Type.DOUBLE_TYPE;
+			case FLOAT -> Type.FLOAT_TYPE;
 			case BOOLEAN -> Type.BOOLEAN_TYPE;
 			case CHAR -> Type.CHAR_TYPE;
 			default -> null;

--- a/src/water/compiler/parser/nodes/variable/AssignmentNode.java
+++ b/src/water/compiler/parser/nodes/variable/AssignmentNode.java
@@ -70,6 +70,13 @@ public class AssignmentNode implements Node {
 			throw new SemanticException(name, "Reassignment of constant '%s'.".formatted(name.getValue()));
 		}
 
+		if(variable.getVariableType() == VariableType.CLASS) {
+			if(context.getContext().isStaticMethod())  throw new SemanticException(name, "Cannot access instance member '%s' in a static context".formatted(name.getValue()));
+			context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
+		}
+
+		right.visit(context);
+
 		try {
 			if(!TypeUtil.isAssignableFrom(variable.getType(), returnType, context.getContext(), true)) {
 				throw new SemanticException(op,
@@ -84,17 +91,12 @@ public class AssignmentNode implements Node {
 		if(!isExpressionStatementBody) methodVisitor.visitInsn(TypeUtil.getDupOpcode(returnType));
 
 		if(variable.getVariableType() == VariableType.STATIC) {
-			right.visit(context);
 			methodVisitor.visitFieldInsn(Opcodes.PUTSTATIC, variable.getOwner(), variable.getName(), variable.getType().getDescriptor());
 		}
 		if(variable.getVariableType() == VariableType.CLASS) {
-			if(context.getContext().isStaticMethod())  throw new SemanticException(name, "Cannot access instance member '%s' in a static context".formatted(name.getValue()));
-			context.getContext().getMethodVisitor().visitVarInsn(Opcodes.ALOAD, 0);
-			right.visit(context);
 			methodVisitor.visitFieldInsn(Opcodes.PUTFIELD, variable.getOwner(), variable.getName(), variable.getType().getDescriptor());
 		}
 		else {
-			right.visit(context);
 			methodVisitor.visitVarInsn(variable.getType().getOpcode(Opcodes.ISTORE), variable.getIndex());
 		}
 	}

--- a/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
@@ -48,7 +48,7 @@ public class VariableDeclarationNode implements Node {
 	public void visit(FileContext context) throws SemanticException {
 		Type returnType = value.getReturnType(context.getContext());
 
-		boolean buildConstructor = context.getContext().getConstructors().size() != 0;
+		boolean buildConstructor = context.getContext().getConstructors() != null && context.getContext().getConstructors().size() != 0;
 
 		if(context.getContext().getType() == ContextType.GLOBAL) {
 			defineGetAndSet(true, true, context.getContext());

--- a/src/water/compiler/util/TypeUtil.java
+++ b/src/water/compiler/util/TypeUtil.java
@@ -367,7 +367,6 @@ public class TypeUtil {
 	 * @param context The context of the method.
 	 */
 	public static void correctLdc(Object object, Context context) {
-		//TODO Other primitive constants
 		if(object == null) {
 			context.getMethodVisitor().visitInsn(Opcodes.ACONST_NULL);
 		}
@@ -391,6 +390,9 @@ public class TypeUtil {
 		}
 		else if(object instanceof Byte) {
 			generateCorrectInt((Byte) object, context);
+		}
+		else if(object instanceof Short) {
+			generateCorrectInt((Short) object, context);
 		}
 		else {
 			context.getMethodVisitor().visitLdcInsn(object);

--- a/src/water/compiler/util/TypeUtil.java
+++ b/src/water/compiler/util/TypeUtil.java
@@ -87,7 +87,8 @@ public class TypeUtil {
 					type.getSort() == Type.BYTE ||
 					type.getSort() == Type.CHAR ||
 					type.getSort() == Type.SHORT ||
-					type.getSort() == Type.LONG
+					type.getSort() == Type.LONG ||
+					type.getSort() == Type.BOOLEAN
 				);
 	}
 

--- a/src/water/compiler/util/TypeUtil.java
+++ b/src/water/compiler/util/TypeUtil.java
@@ -91,6 +91,20 @@ public class TypeUtil {
 					type.getSort() == Type.BOOLEAN
 				);
 	}
+	/**
+	 * If the type represents an integer type - excluding long.
+	 * @param type The type to check
+	 * @return If the type is an integer type
+	 */
+	public static boolean isRepresentedAsInteger(Type type) {
+		return isPrimitive(type) && (
+				type.getSort() == Type.INT ||
+				type.getSort() == Type.BYTE ||
+				type.getSort() == Type.CHAR ||
+				type.getSort() == Type.SHORT ||
+				type.getSort() == Type.BOOLEAN
+		);
+	}
 
 	/**
 	 *
@@ -240,6 +254,10 @@ public class TypeUtil {
 				if(convert) cast(context.getMethodVisitor(), from, to);
 				return true;
 			}
+			if(isRepresentedAsInteger(to) && isRepresentedAsInteger(from)) {
+				if(convert) cast(context.getMethodVisitor(), from, to);
+				return true;
+			}
 			return false;
 		}
 
@@ -370,6 +388,9 @@ public class TypeUtil {
 		}
 		else if(object instanceof Long) {
 			generateCorrectLong((Long) object, context);
+		}
+		else if(object instanceof Byte) {
+			generateCorrectInt((Byte) object, context);
 		}
 		else {
 			context.getMethodVisitor().visitLdcInsn(object);

--- a/src/water/compiler/util/TypeUtil.java
+++ b/src/water/compiler/util/TypeUtil.java
@@ -335,6 +335,9 @@ public class TypeUtil {
 		else if(object instanceof Boolean) {
 			context.getMethodVisitor().visitInsn(((Boolean) object).booleanValue() ? Opcodes.ICONST_1 : Opcodes.ICONST_0);
 		}
+		else if(object instanceof Character) {
+			generateCorrectInt(((Character) object).charValue(), context);
+		}
 		else {
 			context.getMethodVisitor().visitLdcInsn(object);
 		}

--- a/src/water/compiler/util/TypeUtil.java
+++ b/src/water/compiler/util/TypeUtil.java
@@ -317,6 +317,20 @@ public class TypeUtil {
 	}
 
 	/**
+	 * Creates the optimal opcode for the given float.
+	 * @param val The float to generate bytecode for.
+	 * @param context The context of the method.
+	 */
+	public static void generateCorrectFloat(float val, Context context) {
+		MethodVisitor method = context.getMethodVisitor();
+
+		if (val == 0) method.visitInsn(Opcodes.FCONST_0);
+		else if (val == 1) method.visitInsn(Opcodes.FCONST_1);
+		else if (val == 2) method.visitInsn(Opcodes.FCONST_2);
+		else method.visitLdcInsn(val);
+	}
+
+	/**
 	 * Given an object, creates the optimal opcode to load it in bytecode (where possible).
 	 * @param object The object to add to bytecode.
 	 * @param context The context of the method.
@@ -327,16 +341,19 @@ public class TypeUtil {
 			context.getMethodVisitor().visitInsn(Opcodes.ACONST_NULL);
 		}
 		else if(object instanceof Integer) {
-			generateCorrectInt(((Integer) object).intValue(), context);
+			generateCorrectInt((Integer) object, context);
 		}
 		else if(object instanceof Double) {
-			generateCorrectDouble(((Double) object).doubleValue(), context);
+			generateCorrectDouble((Double) object, context);
+		}
+		else if(object instanceof Float) {
+			generateCorrectFloat((Float) object, context);
 		}
 		else if(object instanceof Boolean) {
-			context.getMethodVisitor().visitInsn(((Boolean) object).booleanValue() ? Opcodes.ICONST_1 : Opcodes.ICONST_0);
+			context.getMethodVisitor().visitInsn((Boolean) object ? Opcodes.ICONST_1 : Opcodes.ICONST_0);
 		}
 		else if(object instanceof Character) {
-			generateCorrectInt(((Character) object).charValue(), context);
+			generateCorrectInt((Character) object, context);
 		}
 		else {
 			context.getMethodVisitor().visitLdcInsn(object);

--- a/src/water/compiler/util/TypeUtil.java
+++ b/src/water/compiler/util/TypeUtil.java
@@ -271,6 +271,36 @@ public class TypeUtil {
 	}
 
 	/**
+	 * Returns how many changes / how simple the conversion between types is. Assumes the types can be cast.
+	 * @param to The type to attempt to cast to
+	 * @param from The type to attempt to cast from
+	 * @return The complexity of the change
+	 */
+	public static int assignChanges(Type to, Type from) {
+		if(to.getSort() == Type.OBJECT && from.getSort() == Type.OBJECT) {
+			return 1;
+		}
+
+		else if(isPrimitive(to) && isPrimitive(from)) {
+			if(TYPE_SIZE.indexOf(to.getSort()) <= TYPE_SIZE.indexOf(from.getSort())) {
+				return 1;
+			}
+			if(isRepresentedAsInteger(to) && isRepresentedAsInteger(from)) {
+				return 2;
+			}
+		}
+
+		if(to.getSort() == Type.ARRAY && from.getSort() == Type.ARRAY) {
+			return 0;
+		}
+
+		//TODO Auto-boxing
+
+		assert false;
+		return -1;
+	}
+
+	/**
 	 * Gets the appropriate compare opcode for types double, float, and long.
 	 * Adds this opcode to the method visitor.
 	 * @param mv The method visitor to use.

--- a/src/water/compiler/util/TypeUtil.java
+++ b/src/water/compiler/util/TypeUtil.java
@@ -331,6 +331,19 @@ public class TypeUtil {
 	}
 
 	/**
+	 * Creates the optimal opcode for the given long.
+	 * @param val The float to generate bytecode for.
+	 * @param context The context of the method.
+	 */
+	public static void generateCorrectLong(long val, Context context) {
+		MethodVisitor method = context.getMethodVisitor();
+
+		if (val == 0) method.visitInsn(Opcodes.LCONST_0);
+		else if (val == 1) method.visitInsn(Opcodes.LCONST_1);
+		else method.visitLdcInsn(val);
+	}
+
+	/**
 	 * Given an object, creates the optimal opcode to load it in bytecode (where possible).
 	 * @param object The object to add to bytecode.
 	 * @param context The context of the method.
@@ -354,6 +367,9 @@ public class TypeUtil {
 		}
 		else if(object instanceof Character) {
 			generateCorrectInt((Character) object, context);
+		}
+		else if(object instanceof Long) {
+			generateCorrectLong((Long) object, context);
 		}
 		else {
 			context.getMethodVisitor().visitLdcInsn(object);


### PR DESCRIPTION
The primitive types are: int, double, float, boolean, long, byte, short, and char.
All of these can now be used within Water.

A suffix of 'f' or 'F' can be used on a number to represent a float constant.
A suffix of 'l' or 'L' can be used on an integer to represent a long constant.
Chars support the `'<chr>'` syntax, such as `'a'` or `'$'`