### PR TITLE
Support for Inplace Operators

### DIFF
--- a/src/water/compiler/compiler/Scope.java
+++ b/src/water/compiler/compiler/Scope.java
@@ -108,7 +108,7 @@ public class Scope {
 					continue out;
 
 				if (TypeUtil.isAssignableFrom(expectArg, arg, context, false)) {
-					if (!expectArg.equals(arg)) changes++;
+					if (!expectArg.equals(arg)) changes += TypeUtil.assignChanges(expectArg, arg);
 				} else {
 					continue out;
 				}

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -81,11 +81,11 @@ public class Lexer {
 					case ']' -> TokenType.RSQBR;
 					case ';' -> TokenType.SEMI;
 					case ',' -> TokenType.COMMA;
-					case '+' -> TokenType.PLUS;
-					case '-' -> next('>') ? TokenType.ARROW : TokenType.MINUS;
-					case '*' -> TokenType.STAR;
-					case '/' -> TokenType.SLASH;
-					case '%' -> TokenType.PERCENT;
+					case '+' -> next('=') ? TokenType.IN_PLUS : TokenType.PLUS;
+					case '-' -> next('>') ? TokenType.ARROW : next('=') ? TokenType.IN_MINUS :TokenType.MINUS;
+					case '*' -> next('=') ? TokenType.IN_MUL : TokenType.STAR;
+					case '/' -> next('=') ? TokenType.IN_DIV : TokenType.SLASH;
+					case '%' -> next('=') ? TokenType.IN_MOD : TokenType.PERCENT;
 					case '=' -> next('=') ? (next('=') ? TokenType.TRI_EQ : TokenType.EQEQ) : TokenType.EQUALS;
 					case ':' -> TokenType.COLON;
 					case '.' -> TokenType.DOT;

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -22,6 +22,13 @@ public enum TokenType {
 	EXEQ, TRI_EXEQ,
 	LESS_EQ, GREATER_EQ,
 
+	// Inplace
+	IN_PLUS,
+	IN_MINUS,
+	IN_MUL,
+	IN_DIV,
+	IN_MOD,
+
 	// Identifiers / Keywords
 	IDENTIFIER,
 	IMPORT,

--- a/src/water/compiler/parser/Parser.java
+++ b/src/water/compiler/parser/Parser.java
@@ -322,7 +322,7 @@ public class Parser {
 
 	/*
 	Precedence:
-	assignExpr =
+	assignExpr = += (etc)
 	equalityExpr == != === !==
 	relativeExpr < <= > >=
 	arithExpr + -
@@ -335,11 +335,11 @@ public class Parser {
 		return assignExpr();
 	}
 
-	/** Forms grammar: equalityExpr ('=' equalityExpr)* */
+	/** Forms grammar: equalityExpr (('=' | INPLACE_OPERATOR) equalityExpr)* */
 	private Node assignExpr() throws UnexpectedTokenException {
 		Node left = equalityExpr();
 
-		while(match(TokenType.EQUALS)) {
+		while(matchAssignment()) {
 			Token op = tokens.get(index - 1);
 
 			Node right = equalityExpr();
@@ -597,6 +597,16 @@ public class Parser {
 	}
 
 	//============================ Helpers =============================
+
+	private boolean matchAssignment() {
+		switch (tokens.get(index).getType()) {
+			case EQUALS, IN_PLUS, IN_MINUS, IN_MUL, IN_DIV, IN_MOD -> {
+				advance();
+				return true;
+			}
+		}
+		return false;
+	}
 
 	private boolean match(TokenType type) {
 		if(tokens.get(index).getType() != type) return false;

--- a/src/water/compiler/parser/nodes/classes/MethodCallNode.java
+++ b/src/water/compiler/parser/nodes/classes/MethodCallNode.java
@@ -128,7 +128,7 @@ public class MethodCallNode implements Node {
 						continue out;
 
 					if (TypeUtil.isAssignableFrom(expectArg, arg, context, false)) {
-						if (!expectArg.equals(arg)) changes++;
+						if (!expectArg.equals(arg)) changes += TypeUtil.assignChanges(expectArg, arg);
 					} else {
 						continue out;
 					}

--- a/src/water/compiler/parser/nodes/classes/ObjectConstructorNode.java
+++ b/src/water/compiler/parser/nodes/classes/ObjectConstructorNode.java
@@ -118,7 +118,7 @@ public class ObjectConstructorNode implements Node {
 						continue out;
 
 					if (TypeUtil.isAssignableFrom(expectArg, arg, context.getContext(), false)) {
-						if (!expectArg.equals(arg)) changes++;
+						if (!expectArg.equals(arg)) changes += TypeUtil.assignChanges(expectArg, arg);
 					} else {
 						continue out;
 					}


### PR DESCRIPTION
### Inplace Operators
Inplace Operators remove the need to replicate the left-hand-side on the right-hand-side to perform an operation.
E.g.
```javascript
var x = 10;
x += 5;
println(x); // 15
```

### Arithmetic Inplace Operators
The arithmetic inplace operators are:
 - `+=`
 - `-=`
 - `*=`
 - `/=`
 - `%=`