### PR TITLE
Import Water Compilation Files

### DIFF
--- a/src/water/compiler/FileContext.java
+++ b/src/water/compiler/FileContext.java
@@ -16,7 +16,7 @@ import java.util.Properties;
 public class FileContext {
 	private final Node ast;
 	private final Context context;
-	private final Map<String, Class<?>> classMap;
+	private Map<String, Class<?>> classMap;
 	private final Path path;
 	private final Properties optimizations;
 
@@ -38,6 +38,10 @@ public class FileContext {
 
 	public Map<String, Class<?>> getClassMap() {
 		return classMap;
+	}
+
+	public void setClassMap(Map<String, Class<?>> classMap) {
+		this.classMap = classMap;
 	}
 
 	public Path getPath() {

--- a/src/water/compiler/parser/Node.java
+++ b/src/water/compiler/parser/Node.java
@@ -25,4 +25,6 @@ public interface Node {
 	default Object[] getLValueData() { return new Object[0]; }
 	/** If the Node produces a new class file */
 	default boolean isNewClass() { return false; }
+	/** Create classes definitions */
+	default void buildClasses(Context context) throws SemanticException {}
 }

--- a/src/water/compiler/parser/nodes/block/ProgramNode.java
+++ b/src/water/compiler/parser/nodes/block/ProgramNode.java
@@ -31,6 +31,31 @@ public class ProgramNode implements Node {
 	}
 
 	@Override
+	public void buildClasses(Context context) throws SemanticException {
+		String packageN = packageName == null ? "" : packageName.getReturnType(context).getInternalName();
+		context.setPackageName(packageN);
+
+		String source = context.getSource();
+		String name = source.substring(0, source.indexOf(".")) + "Wtr";
+
+		standaloneClass = declarations.stream().filter(n -> !n.isNewClass()).toArray().length != 0;
+
+		ClassWriter writer = null;
+
+		if(standaloneClass) {
+			writer = initClass(name, context);
+		}
+
+		for(Node n : declarations) {
+			n.buildClasses(context);
+		}
+
+		if(standaloneClass) {
+			writer.visitEnd();
+		}
+	}
+
+	@Override
 	public void preprocess(Context context) throws SemanticException {
 		String packageN = packageName == null ? "" : packageName.getReturnType(context).getInternalName();
 		context.setPackageName(packageN);
@@ -99,7 +124,7 @@ public class ProgramNode implements Node {
 		}
 	}
 
-	private ClassWriter initClass(String name, Context context) throws SemanticException {
+	private ClassWriter initClass(String name, Context context) {
 		context.setType(ContextType.GLOBAL);
 
 		String source = context.getSource();

--- a/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
@@ -31,6 +31,19 @@ public class ClassDeclarationNode implements Node {
 	}
 
 	@Override
+	public void buildClasses(Context context) {
+		ContextType prevType = context.getType();
+		String prevClass = context.getCurrentClass();
+
+		ClassWriter writer = initClass(context);
+
+		writer.visitEnd();
+
+		context.setType(prevType);
+		context.setCurrentClass(prevClass);
+	}
+
+	@Override
 	public void visit(FileContext fc) throws SemanticException {
 		Context context = fc.getContext();
 		ContextType prevType = context.getType();

--- a/src/water/compiler/parser/nodes/special/ImportNode.java
+++ b/src/water/compiler/parser/nodes/special/ImportNode.java
@@ -18,8 +18,12 @@ public class ImportNode implements Node {
 	}
 
 	@Override
-	public void visit(FileContext fc) throws SemanticException {
-		Context context = fc.getContext();
+	public void visit(FileContext context) throws SemanticException {
+		// Do nothing
+	}
+
+	@Override
+	public void preprocess(Context context) throws SemanticException {
 		Type importType = type.getReturnType(context);
 
 		if(TypeUtil.isPrimitive(importType)) {
@@ -34,19 +38,6 @@ public class ImportNode implements Node {
 		}
 
 		context.getImports().put(klass.getSimpleName(), importType.getClassName());
-	}
-
-	@Override
-	public void preprocess(Context context) throws SemanticException {
-		Type importType = Type.getObjectType(type.toString());
-
-		if(TypeUtil.isPrimitive(importType)) {
-			throw new SemanticException(importTok, "Cannot import primitive type");
-		}
-
-		String className = importType.getClassName();
-		String simpleName = className.contains(".") ? className.substring(className.lastIndexOf('.')) : className;
-		context.getImports().put(simpleName, className);
 	}
 
 	@Override


### PR DESCRIPTION
This request fixes a bug where imports between two files currently being compiled would not work correctly.
For example, given this project stucture:
```
src
  - Pair.wtr
  - Test.wtr
```
Where `Pair.wtr` contains:
```
class Pair {
	var x = null;
	var y = null;

	constructor(x: Object, y: Object) {
		this.x = x;
		this.y = y;
	}

	function toString() = "[" + x + ", " + y + "]";
}
```
And `Test.wtr` contains:
```
import Pair;

function makePair() -> Pair { // Would Previously Fail Here in the preprocessing stage
	return new Pair("hello", "world");
}

function main() {
	println(makePair());
}
```
Due to the processing step happening for Test.wtr before Pair.wtr, the import could not be used correctly.

The preprocess step has therefore been split into two parts, 'build classes' and preprocessing.

The build classes step is done first, simply adding a definition for a class to the class pool.

The preprocessing step will then fill these classes with function and variable definitions.

Finally, the visiting step will fill these definitions with their implementations, and output the final bytecode.