### PR TITLE
Bitwise Operations

### DIFF
--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -101,8 +101,8 @@ public class Lexer {
 					case ':' -> TokenType.COLON;
 					case '.' -> TokenType.DOT;
 					case '!' -> next('=') ? (next('=') ? TokenType.TRI_EXEQ : TokenType.EXEQ) : TokenType.EXCLAIM;
-					case '<' -> next('=') ? TokenType.LESS_EQ : TokenType.LESS;
-					case '>' -> next('=') ? TokenType.GREATER_EQ : TokenType.GREATER;
+					case '<' -> next('=') ? TokenType.LESS_EQ : next('<') ? TokenType.BITWISE_SHL : TokenType.LESS;
+					case '>' -> lexGreaterThan();
 					case '&' -> next('&') ? TokenType.LOGICAL_AND : TokenType.BITWISE_AND;
 					case '|' -> next('|') ? TokenType.LOGICAL_OR : TokenType.BITWISE_OR;
 					case '^' -> TokenType.BITWISE_XOR;
@@ -116,6 +116,20 @@ public class Lexer {
 		tokens.add(makeToken(TokenType.EOF));
 
 		return tokens;
+	}
+
+	/** Matches against different tokens which start with '>' */
+	private TokenType lexGreaterThan() {
+		if(next('=')) {
+			return TokenType.GREATER_EQ;
+		}
+		else if(next('>')) {
+			if(next('>')) {
+				return TokenType.BITWISE_USHR;
+			}
+			return TokenType.BITWISE_SHR;
+		}
+		return TokenType.GREATER;
 	}
 
 	/**

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -103,9 +103,9 @@ public class Lexer {
 					case '!' -> next('=') ? (next('=') ? TokenType.TRI_EXEQ : TokenType.EXEQ) : TokenType.EXCLAIM;
 					case '<' -> next('=') ? TokenType.LESS_EQ : next('<') ? TokenType.BITWISE_SHL : TokenType.LESS;
 					case '>' -> lexGreaterThan();
-					case '&' -> next('&') ? TokenType.LOGICAL_AND : TokenType.BITWISE_AND;
-					case '|' -> next('|') ? TokenType.LOGICAL_OR : TokenType.BITWISE_OR;
-					case '^' -> TokenType.BITWISE_XOR;
+					case '&' -> next('&') ? TokenType.LOGICAL_AND : next('=') ? TokenType.IN_BITWISE_AND : TokenType.BITWISE_AND;
+					case '|' -> next('|') ? TokenType.LOGICAL_OR : next('=') ? TokenType.IN_BITWISE_OR : TokenType.BITWISE_OR;
+					case '^' -> next('=') ? TokenType.IN_BITWISE_XOR : TokenType.BITWISE_XOR;
 					case '~' -> TokenType.BITWISE_NOT;
 					default -> TokenType.ERROR;
 				};
@@ -125,7 +125,13 @@ public class Lexer {
 			return TokenType.GREATER_EQ;
 		}
 		else if(next('>')) {
-			if(next('>')) {
+			if(next('=')) {
+				return TokenType.IN_BITWISE_SHR;
+			}
+			else if(next('>')) {
+				if(next('=')) {
+					return TokenType.IN_BITWISE_USHR;
+				}
 				return TokenType.BITWISE_USHR;
 			}
 			return TokenType.BITWISE_SHR;
@@ -296,8 +302,7 @@ public class Lexer {
 	 * @return The created token.
 	 */
 	private Token makeToken(TokenType type) {
-		Token token = new Token(type, text.substring(start, index), line, column);
-		return token;
+		return new Token(type, text.substring(start, index), line, column);
 	}
 
 	/**

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -106,6 +106,7 @@ public class Lexer {
 					case '&' -> next('&') ? TokenType.LOGICAL_AND : TokenType.BITWISE_AND;
 					case '|' -> next('|') ? TokenType.LOGICAL_OR : TokenType.BITWISE_OR;
 					case '^' -> TokenType.BITWISE_XOR;
+					case '~' -> TokenType.BITWISE_NOT;
 					default -> TokenType.ERROR;
 				};
 				token = makeToken(type);

--- a/src/water/compiler/lexer/Lexer.java
+++ b/src/water/compiler/lexer/Lexer.java
@@ -105,6 +105,7 @@ public class Lexer {
 					case '>' -> next('=') ? TokenType.GREATER_EQ : TokenType.GREATER;
 					case '&' -> next('&') ? TokenType.LOGICAL_AND : TokenType.BITWISE_AND;
 					case '|' -> next('|') ? TokenType.LOGICAL_OR : TokenType.BITWISE_OR;
+					case '^' -> TokenType.BITWISE_XOR;
 					default -> TokenType.ERROR;
 				};
 				token = makeToken(type);

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -26,6 +26,9 @@ public enum TokenType {
 	LESS_EQ, GREATER_EQ,
 	LOGICAL_AND,
 	LOGICAL_OR,
+	BITWISE_SHL,
+	BITWISE_SHR,
+	BITWISE_USHR,
 
 	// Inplace
 	IN_PLUS,

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -37,6 +37,12 @@ public enum TokenType {
 	IN_MUL,
 	IN_DIV,
 	IN_MOD,
+	IN_BITWISE_SHL,
+	IN_BITWISE_SHR,
+	IN_BITWISE_USHR,
+	IN_BITWISE_AND,
+	IN_BITWISE_OR,
+	IN_BITWISE_XOR,
 
 	// Identifiers / Keywords
 	IDENTIFIER,

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -17,6 +17,7 @@ public enum TokenType {
 	LESS, GREATER,
 	BITWISE_AND,
 	BITWISE_OR,
+	BITWISE_XOR,
 
 	// Multi character
 	ARROW,

--- a/src/water/compiler/lexer/TokenType.java
+++ b/src/water/compiler/lexer/TokenType.java
@@ -18,6 +18,7 @@ public enum TokenType {
 	BITWISE_AND,
 	BITWISE_OR,
 	BITWISE_XOR,
+	BITWISE_NOT,
 
 	// Multi character
 	ARROW,

--- a/src/water/compiler/parser/Parser.java
+++ b/src/water/compiler/parser/Parser.java
@@ -440,6 +440,7 @@ public class Parser {
 	bitwiseAndExpr &
 	equalityExpr == != === !==
 	relativeExpr < <= > >=
+	shiftExpr << >> >>>
 	arithExpr + -
 	term * / %
 	atom (value)
@@ -521,7 +522,7 @@ public class Parser {
 		return left;
 	}
 
-	/** Forms grammar: equalityExpr ('^' equalityExpr)* */
+	/** Forms grammar: equalityExpr ('&' equalityExpr)* */
 	private Node bitwiseAndExpr() throws UnexpectedTokenException {
 		Node left = equalityExpr();
 
@@ -549,16 +550,30 @@ public class Parser {
 		return left;
 	}
 
-	/** Forms grammar: arithExpr (('<' | '<=' | '>' '>=') arithExpr)* */
+	/** Forms grammar: shiftExpr (({@literal '<' | '<=' | '>' '>='}) shiftExpr)* */
 	private Node relativeExpr() throws UnexpectedTokenException {
-		Node left = arithExpr();
+		Node left = shiftExpr();
 
 		while(match(TokenType.LESS) || match(TokenType.LESS_EQ) || match(TokenType.GREATER) || match(TokenType.GREATER_EQ)) {
 			Token op = tokens.get(index - 1);
 
-			Node right = arithExpr();
+			Node right = shiftExpr();
 
 			left = new RelativeOperationNode(left, op, right);
+		}
+		return left;
+	}
+
+	/** Forms grammar: arithExpr (({@literal '<<' | '>>' | '>>>'}) arithExpr)* */
+	private Node shiftExpr() throws UnexpectedTokenException {
+		Node left = arithExpr();
+
+		while(match(TokenType.BITWISE_SHL) || match(TokenType.BITWISE_SHR) || match(TokenType.BITWISE_USHR)) {
+			Token op = tokens.get(index - 1);
+
+			Node right = arithExpr();
+
+			left = new IntegerOperationNode(left, op, right);
 		}
 		return left;
 	}

--- a/src/water/compiler/parser/Parser.java
+++ b/src/water/compiler/parser/Parser.java
@@ -622,7 +622,7 @@ public class Parser {
 
 	/** Forms grammar: ('!' | '-') unary | memberAccess */
 	private Node unary() throws UnexpectedTokenException {
-		if(match(TokenType.EXCLAIM) || match(TokenType.MINUS)) {
+		if(match(TokenType.EXCLAIM) || match(TokenType.MINUS) || match(TokenType.BITWISE_NOT)) {
 			Token op = tokens.get(index - 1);
 
 			Node right = unary();

--- a/src/water/compiler/parser/Parser.java
+++ b/src/water/compiler/parser/Parser.java
@@ -814,7 +814,8 @@ public class Parser {
 
 	private boolean matchAssignment() {
 		switch (tokens.get(index).getType()) {
-			case EQUALS, IN_PLUS, IN_MINUS, IN_MUL, IN_DIV, IN_MOD -> {
+			case EQUALS, IN_PLUS, IN_MINUS, IN_MUL, IN_DIV, IN_MOD,
+					IN_BITWISE_AND, IN_BITWISE_OR, IN_BITWISE_XOR, IN_BITWISE_SHL, IN_BITWISE_SHR, IN_BITWISE_USHR -> {
 				advance();
 				return true;
 			}

--- a/src/water/compiler/parser/Parser.java
+++ b/src/water/compiler/parser/Parser.java
@@ -435,6 +435,9 @@ public class Parser {
 	assignExpr = += (etc)
 	logicalOrExpr ||
 	logicalAndExpr &&
+	bitwiseOrExpr |
+	bitwiseXorExpr ^
+	bitwiseAndExpr &
 	equalityExpr == != === !==
 	relativeExpr < <= > >=
 	arithExpr + -
@@ -476,16 +479,58 @@ public class Parser {
 		return left;
 	}
 
-	/** Forms grammar: equalityExpr ('&&' equalityExpr)* */
+	/** Forms grammar: bitwiseOrExpr ('&&' bitwiseOrExpr)* */
 	private Node logicalAndExpr() throws UnexpectedTokenException {
-		Node left = equalityExpr();
+		Node left = bitwiseOrExpr();
 
 		while(match(TokenType.LOGICAL_AND)) {
 			Token op = tokens.get(index - 1);
 
-			Node right = equalityExpr();
+			Node right = bitwiseOrExpr();
 
 			left = new LogicalOperationNode(left, op, right);
+		}
+		return left;
+	}
+
+	/** Forms grammar: bitwiseXorExpr ('|' bitwiseXorExpr)* */
+	private Node bitwiseOrExpr() throws UnexpectedTokenException {
+		Node left = bitwiseXorExpr();
+
+		while(match(TokenType.BITWISE_OR)) {
+			Token op = tokens.get(index - 1);
+
+			Node right = bitwiseXorExpr();
+
+			left = new IntegerOperationNode(left, op, right);
+		}
+		return left;
+	}
+
+	/** Forms grammar: bitwiseAndExpr ('^' bitwiseAndExpr)* */
+	private Node bitwiseXorExpr() throws UnexpectedTokenException {
+		Node left = bitwiseAndExpr();
+
+		while(match(TokenType.BITWISE_XOR)) {
+			Token op = tokens.get(index - 1);
+
+			Node right = bitwiseAndExpr();
+
+			left = new IntegerOperationNode(left, op, right);
+		}
+		return left;
+	}
+
+	/** Forms grammar: equalityExpr ('^' equalityExpr)* */
+	private Node bitwiseAndExpr() throws UnexpectedTokenException {
+		Node left = equalityExpr();
+
+		while(match(TokenType.BITWISE_AND)) {
+			Token op = tokens.get(index - 1);
+
+			Node right = equalityExpr();
+
+			left = new IntegerOperationNode(left, op, right);
 		}
 		return left;
 	}

--- a/src/water/compiler/parser/nodes/operation/IntegerOperationNode.java
+++ b/src/water/compiler/parser/nodes/operation/IntegerOperationNode.java
@@ -59,6 +59,9 @@ public class IntegerOperationNode implements Node {
 			case BITWISE_OR -> Opcodes.IOR;
 			case BITWISE_XOR -> Opcodes.IXOR;
 			case BITWISE_AND -> Opcodes.IAND;
+			case BITWISE_SHL -> Opcodes.ISHL;
+			case BITWISE_SHR -> Opcodes.ISHR;
+			case BITWISE_USHR -> Opcodes.IUSHR;
 			default -> throw new IllegalStateException("Invalid operation of '%s' in IntegerOperationNode".formatted(op.getType()));
 		};
 	}

--- a/src/water/compiler/parser/nodes/operation/IntegerOperationNode.java
+++ b/src/water/compiler/parser/nodes/operation/IntegerOperationNode.java
@@ -1,0 +1,75 @@
+package water.compiler.parser.nodes.operation;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import water.compiler.FileContext;
+import water.compiler.compiler.Context;
+import water.compiler.compiler.SemanticException;
+import water.compiler.lexer.Token;
+import water.compiler.parser.Node;
+import water.compiler.util.TypeUtil;
+
+public class IntegerOperationNode implements Node {
+
+	private final Node left;
+	private final Token op;
+	private final Node right;
+
+	public IntegerOperationNode(Node left, Token op, Node right) {
+		this.left = left;
+		this.op = op;
+		this.right = right;
+	}
+
+	@Override
+	public void visit(FileContext context) throws SemanticException {
+		Type leftType = left.getReturnType(context.getContext());
+		Type rightType = right.getReturnType(context.getContext());
+
+		if(!TypeUtil.isInteger(leftType) || !TypeUtil.isInteger(rightType)) {
+			throw new SemanticException(op, "Unsupported operation of '%s' between types '%s' and '%s'".formatted(
+					op.getValue(), TypeUtil.stringify(leftType), TypeUtil.stringify(rightType)
+			));
+		}
+
+		MethodVisitor visitor = context.getContext().getMethodVisitor();
+
+		Type larger = TypeUtil.getLarger(leftType, rightType);
+
+		boolean same = leftType.getSort() == rightType.getSort();
+
+		left.visit(context);
+
+		if(!same && larger.getSort() == rightType.getSort()) {
+			TypeUtil.cast(visitor, leftType, rightType);
+		}
+
+		right.visit(context);
+
+		if(!same && larger.getSort() == leftType.getSort()) {
+			TypeUtil.cast(visitor, rightType, leftType);
+		}
+
+		visitor.visitInsn(larger.getOpcode(getOpcode()));
+	}
+
+	private int getOpcode() {
+		return switch (op.getType()) {
+			case BITWISE_OR -> Opcodes.IOR;
+			case BITWISE_XOR -> Opcodes.IXOR;
+			case BITWISE_AND -> Opcodes.IAND;
+			default -> throw new IllegalStateException("Invalid operation of '%s' in IntegerOperationNode".formatted(op.getType()));
+		};
+	}
+
+	@Override
+	public Type getReturnType(Context context) throws SemanticException {
+		return TypeUtil.getLarger(left.getReturnType(context), right.getReturnType(context));
+	}
+
+	@Override
+	public String toString() {
+		return "%s %s %s".formatted(left, op.getValue(), right);
+	}
+}

--- a/src/water/compiler/parser/nodes/variable/AssignmentNode.java
+++ b/src/water/compiler/parser/nodes/variable/AssignmentNode.java
@@ -13,6 +13,7 @@ import water.compiler.lexer.TokenType;
 import water.compiler.parser.LValue;
 import water.compiler.parser.Node;
 import water.compiler.parser.nodes.operation.ArithmeticOperationNode;
+import water.compiler.parser.nodes.operation.IntegerOperationNode;
 import water.compiler.parser.nodes.value.ThisNode;
 import water.compiler.util.TypeUtil;
 
@@ -231,15 +232,32 @@ public class AssignmentNode implements Node {
 			case IN_MUL -> TokenType.STAR;
 			case IN_DIV -> TokenType.SLASH;
 			case IN_MOD -> TokenType.PERCENT;
+			case IN_BITWISE_AND -> TokenType.BITWISE_AND;
+			case IN_BITWISE_OR -> TokenType.BITWISE_OR;
+			case IN_BITWISE_XOR -> TokenType.BITWISE_XOR;
+			case IN_BITWISE_SHL -> TokenType.BITWISE_SHL;
+			case IN_BITWISE_SHR -> TokenType.BITWISE_SHR;
+			case IN_BITWISE_USHR -> TokenType.BITWISE_USHR;
 			default -> null;
 		}, op.getValue(), op.getLine(), op.getColumn());
+	}
+
+	private boolean isBitwise(TokenType type) {
+		return switch (type) {
+			case IN_BITWISE_AND, IN_BITWISE_OR, IN_BITWISE_XOR, IN_BITWISE_SHL, IN_BITWISE_SHR, IN_BITWISE_USHR -> true;
+			default -> false;
+		};
 	}
 
 	private Node generateSyntheticOperation() {
 		if(op.getType() == TokenType.EQUALS) return right;
 
 		Token syntheticOp = makeSyntheticToken();
-		
+
+		if(isBitwise(op.getType())) {
+			return new IntegerOperationNode(left, syntheticOp, right);
+		}
+
 		return new ArithmeticOperationNode(left, syntheticOp, right);
 	}
 


### PR DESCRIPTION
Implements support for bitwise operations on the integer types.
They are the same as in Java, and are as follows:
- `&`
- `|`
- `^`
- `<<`
- `>>`
- `>>>`
- `~`
All binary bitwise operations have equivalant inplace operations (e.g. `&=`).