### PR TITLE
Type Refactor

### DIFF
--- a/src/water/compiler/compiler/Context.java
+++ b/src/water/compiler/compiler/Context.java
@@ -7,6 +7,7 @@ import org.objectweb.asm.Type;
 import water.compiler.WaterClassLoader;
 import water.compiler.parser.nodes.classes.ConstructorDeclarationNode;
 import water.compiler.parser.nodes.variable.VariableDeclarationNode;
+import water.compiler.util.WaterType;
 
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +29,7 @@ public class Context {
 	private MethodVisitor defaultConstructor;
 	private WaterClassLoader loader;
 	private Scope scope;
-	private Type currentSuperClass;
+	private WaterType currentSuperClass;
 	private boolean isStaticMethod;
 	private boolean isConstructor;
 	private int currentLine;
@@ -116,11 +117,11 @@ public class Context {
 		this.scope = scope;
 	}
 
-	public Type getCurrentSuperClass() {
+	public WaterType getCurrentSuperClass() {
 		return currentSuperClass;
 	}
 
-	public void setCurrentSuperClass(Type currentSuperClass) {
+	public void setCurrentSuperClass(WaterType currentSuperClass) {
 		this.currentSuperClass = currentSuperClass;
 	}
 

--- a/src/water/compiler/compiler/Function.java
+++ b/src/water/compiler/compiler/Function.java
@@ -2,6 +2,7 @@ package water.compiler.compiler;
 
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import water.compiler.util.WaterType;
 
 /**
  * Provides information about a function available without class reference
@@ -10,9 +11,9 @@ public class Function {
 	private final FunctionType functionType;
 	private final String name;
 	private final String owner;
-	private final Type type;
+	private final WaterType type;
 
-	public Function(FunctionType functionType, String name, String owner, Type type) {
+	public Function(FunctionType functionType, String name, String owner, WaterType type) {
 		this.functionType = functionType;
 		this.name = name;
 		this.type = type;
@@ -27,7 +28,7 @@ public class Function {
 		return name;
 	}
 
-	public Type getType() {
+	public WaterType getType() {
 		return type;
 	}
 

--- a/src/water/compiler/compiler/Variable.java
+++ b/src/water/compiler/compiler/Variable.java
@@ -1,6 +1,7 @@
 package water.compiler.compiler;
 
 import org.objectweb.asm.Type;
+import water.compiler.util.WaterType;
 
 /**
  * Represents a variable which can be accessed without class reference.
@@ -8,12 +9,12 @@ import org.objectweb.asm.Type;
 public class Variable {
 	private final String name;
 	private final String owner;
-	private final Type type;
+	private final WaterType type;
 	private final VariableType variableType;
 	private final int index;
 	private final boolean isConst;
 
-	public Variable(VariableType variableType, String name, String owner, Type type, boolean isConst) {
+	public Variable(VariableType variableType, String name, String owner, WaterType type, boolean isConst) {
 		this.name = name;
 		this.owner = owner;
 		this.type = type;
@@ -22,7 +23,7 @@ public class Variable {
 		this.index = 0;
 	}
 
-	public Variable(VariableType variableType, String name, int index, Type type, boolean isConst) {
+	public Variable(VariableType variableType, String name, int index, WaterType type, boolean isConst) {
 		this.variableType = variableType;
 		this.index = index;
 		this.type = type;
@@ -39,7 +40,7 @@ public class Variable {
 		return owner;
 	}
 
-	public Type getType() {
+	public WaterType getType() {
 		return type;
 	}
 

--- a/src/water/compiler/parser/Node.java
+++ b/src/water/compiler/parser/Node.java
@@ -4,6 +4,7 @@ import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
+import water.compiler.util.WaterType;
 
 /**
  * All Nodes created by the Parser in the AST must implement this interface
@@ -14,7 +15,7 @@ public interface Node {
 	/** Create outlining for template class */
 	default void preprocess(Context context) throws SemanticException { }
 	/** The type which this node will produce */
-	default Type getReturnType(Context context) throws SemanticException { return Type.VOID_TYPE; }
+	default WaterType getReturnType(Context context) throws SemanticException { return WaterType.VOID_TYPE; }
 	/** Returns a constant value for use in optimisations. Only needs to be implemented if isConstant can return true */
 	default Object getConstantValue(Context context) throws SemanticException { return null; }
 	/** If the node can be transformed to a constant value for optimisation */

--- a/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
+++ b/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
@@ -10,6 +10,7 @@ import water.compiler.parser.LValue;
 import water.compiler.parser.Node;
 import water.compiler.parser.nodes.variable.VariableAccessNode;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -29,16 +30,16 @@ public class MemberAccessNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
-		Type leftType = getLeftType(context.getContext());
+		WaterType leftType = getLeftType(context.getContext());
 
-		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length")) {
+		if(leftType.isArray() && name.getValue().equals("length")) {
 			left.visit(context);
 			context.getContext().getMethodVisitor().visitInsn(Opcodes.ARRAYLENGTH);
 			return;
 		}
 
-		if(leftType.getSort() != Type.OBJECT) {
-			throw new SemanticException(name, "Cannot access member on type '%s'".formatted(TypeUtil.stringify(leftType)));
+		if(!leftType.isObject()) {
+			throw new SemanticException(name, "Cannot access member on type '%s'".formatted(leftType));
 		}
 
 		left.visit(context);
@@ -47,26 +48,26 @@ public class MemberAccessNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		Type leftType = getLeftType(context);
+	public WaterType getReturnType(Context context) throws SemanticException {
+		WaterType leftType = getLeftType(context);
 
-		if(leftType.getSort() == Type.ARRAY && name.getValue().equals("length")) return Type.INT_TYPE;
+		if(leftType.isArray() && name.getValue().equals("length")) return WaterType.INT_TYPE;
 
 		return resolve(leftType, context, false);
 	}
 
-	private Type getLeftType(Context context) throws SemanticException {
+	private WaterType getLeftType(Context context) throws SemanticException {
 		if(left instanceof VariableAccessNode) {
 			VariableAccessNode van = (VariableAccessNode) left;
 			van.setMemberAccess(true);
-			Type leftType = left.getReturnType(context);
+			WaterType leftType = left.getReturnType(context);
 			isStaticAccess = van.isStaticClassAccess();
-			return  leftType;
+			return leftType;
 		}
 		return left.getReturnType(context);
 	}
 
-	private Type resolve(Type leftType, Context context, boolean generate) throws SemanticException {
+	private WaterType resolve(WaterType leftType, Context context, boolean generate) throws SemanticException {
 		Class<?> klass;
 
 		try {
@@ -79,7 +80,7 @@ public class MemberAccessNode implements Node {
 			Field f = klass.getDeclaredField(name.getValue());
 
 			//TODO Protected
-			if(!Modifier.isPublic(f.getModifiers()) && !leftType.equals(Type.getObjectType(context.getCurrentClass()))) {
+			if(!Modifier.isPublic(f.getModifiers()) && !leftType.equals(WaterType.getObjectType(context.getCurrentClass()))) {
 				throw new NoSuchFieldException();
 			}
 
@@ -92,7 +93,7 @@ public class MemberAccessNode implements Node {
 						leftType.getInternalName(), name.getValue(), Type.getType(f.getType()).getDescriptor());
 			}
 
-			return Type.getType(f.getType());
+			return WaterType.getType(f.getType());
 		} catch (NoSuchFieldException e) {
 			String base = name.getValue();
 			String getName = "get" + base.substring(0, 1).toUpperCase() + base.substring(1);
@@ -104,16 +105,16 @@ public class MemberAccessNode implements Node {
 				try {
 					return attemptMethodCall(klass, leftType, base, generate, context);
 				} catch (NoSuchMethodException suchMethodException) {
-					throw new SemanticException(name, "Could not resolve field '%s' in class '%s'".formatted(name.getValue(), TypeUtil.stringify(leftType)));
+					throw new SemanticException(name, "Could not resolve field '%s' in class '%s'".formatted(name.getValue(), leftType));
 				}
 			}
 		}
 	}
 
-	private Type attemptMethodCall(Class<?> klass, Type leftType, String methodName, boolean generate, Context context) throws NoSuchMethodException, SemanticException {
+	private WaterType attemptMethodCall(Class<?> klass, WaterType leftType, String methodName, boolean generate, Context context) throws NoSuchMethodException, SemanticException {
 		Method m = klass.getMethod(methodName);
 
-		Type returnType = Type.getType(m.getReturnType());
+		WaterType returnType = WaterType.getType(m.getReturnType());
 
 		if(!isStaticAccess && Modifier.isStatic(m.getModifiers())) {
 			throw new SemanticException(name, "Cannot access static member from non-static object.");

--- a/src/water/compiler/parser/nodes/classes/SuperNode.java
+++ b/src/water/compiler/parser/nodes/classes/SuperNode.java
@@ -7,6 +7,7 @@ import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
+import water.compiler.util.WaterType;
 
 public class SuperNode implements Node {
 
@@ -23,7 +24,7 @@ public class SuperNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
+	public WaterType getReturnType(Context context) throws SemanticException {
 		if(context.getCurrentSuperClass() == null) {
 			throw new SemanticException(superTok, "Can only use 'super' within a class.");
 		}

--- a/src/water/compiler/parser/nodes/exception/CatchNode.java
+++ b/src/water/compiler/parser/nodes/exception/CatchNode.java
@@ -3,12 +3,11 @@ package water.compiler.parser.nodes.exception;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.*;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
-import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class CatchNode implements Node {
 	private final Token bindingName;
@@ -36,7 +35,7 @@ public class CatchNode implements Node {
 
 		context.getContext().setScope(outer.nextDepth());
 
-		Type exception = getExceptionType(context.getContext());
+		WaterType exception = getExceptionType(context.getContext());
 
 		int varIndex = context.getContext().getScope().nextLocal();
 		context.getContext().getScope().addVariable(new Variable(VariableType.LOCAL, bindingName.getValue(), varIndex, exception, true));
@@ -69,18 +68,18 @@ public class CatchNode implements Node {
 		}
 	}
 
-	private Type getExceptionType(Context context) throws SemanticException {
-		Type exception = exceptionType.getReturnType(context);
+	private WaterType getExceptionType(Context context) throws SemanticException {
+		WaterType exception = exceptionType.getReturnType(context);
 
-		if(TypeUtil.isPrimitive(exception)) {
-			throw new SemanticException(bindingName, "Cannot throw primitive type (got '%s').".formatted(TypeUtil.stringify(exception)));
+		if(exception.isPrimitive()) {
+			throw new SemanticException(bindingName, "Cannot throw primitive type (got '%s').".formatted(exception));
 		}
 
 		try {
-			if(!TypeUtil.isAssignableFrom(Type.getObjectType("java/lang/Throwable"), exception, context, false)) {
-				throw new SemanticException(bindingName, "throw target must be an extension of java.lang.Throwable ('%s' cannot be cast).".formatted(TypeUtil.stringify(exception)));
+			if(!WaterType.getObjectType("java/lang/Throwable").isAssignableFrom(exception, context, false)) {
+				throw new SemanticException(bindingName, "throw target must be an extension of java.lang.Throwable ('%s' cannot be cast).".formatted(exception));
 			}
-		} catch (ClassNotFoundException | SemanticException e) {
+		} catch (ClassNotFoundException e) {
 			throw new SemanticException(bindingName, "Could not resolve class '%s'".formatted(e.getMessage()));
 		}
 		return exception;

--- a/src/water/compiler/parser/nodes/exception/ThrowNode.java
+++ b/src/water/compiler/parser/nodes/exception/ThrowNode.java
@@ -1,12 +1,11 @@
 package water.compiler.parser.nodes.exception;
 
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
-import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class ThrowNode implements Node {
 	private final Token throwTok;
@@ -19,15 +18,15 @@ public class ThrowNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
-		Type throweeType = throwee.getReturnType(context.getContext());
+		WaterType throweeType = throwee.getReturnType(context.getContext());
 
-		if(TypeUtil.isPrimitive(throweeType)) {
-			throw new SemanticException(throwTok, "Cannot throw primitive type (got '%s').".formatted(TypeUtil.stringify(throweeType)));
+		if(throweeType.isPrimitive()) {
+			throw new SemanticException(throwTok, "Cannot throw primitive type (got '%s').".formatted(throweeType));
 		}
 
 		try {
-			if(!TypeUtil.isAssignableFrom(Type.getObjectType("java/lang/Throwable"), throweeType, context.getContext(), false)) {
-				throw new SemanticException(throwTok, "throw target must be an extension of java.lang.Throwable ('%s' cannot be cast).".formatted(TypeUtil.stringify(throweeType)));
+			if(!WaterType.getObjectType("java/lang/Throwable").isAssignableFrom(throweeType, context.getContext(), false)) {
+				throw new SemanticException(throwTok, "throw target must be an extension of java.lang.Throwable ('%s' cannot be cast).".formatted(throweeType));
 			}
 		} catch (ClassNotFoundException e) {
 			throw new SemanticException(throwTok, "Could not resolve class '%s'".formatted(e.getMessage()));

--- a/src/water/compiler/parser/nodes/function/FunctionCallNode.java
+++ b/src/water/compiler/parser/nodes/function/FunctionCallNode.java
@@ -1,7 +1,6 @@
 package water.compiler.parser.nodes.function;
 
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.Function;
@@ -9,7 +8,7 @@ import water.compiler.compiler.FunctionType;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
-import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,7 +26,7 @@ public class FunctionCallNode implements Node {
 	@Override
 	public void visit(FileContext context) throws SemanticException {
 		context.getContext().updateLine(name.getLine());
-		Type[] argTypes = new Type[args.size()];
+		WaterType[] argTypes = new WaterType[args.size()];
 
 		for(int i = 0; i < args.size(); i++) {
 			Node arg = args.get(i);
@@ -41,7 +40,7 @@ public class FunctionCallNode implements Node {
 			if(function == null) throw new SemanticException(name,
 					"Could not resolve function '%s' with arguments: %s".formatted(name.getValue(),
 							argTypes.length == 0 ? "(none)" :
-							List.of(argTypes).stream().map(TypeUtil::stringify).collect(Collectors.joining(", "))));
+							List.of(argTypes).stream().map(WaterType::toString).collect(Collectors.joining(", "))));
 
 			if(function.getFunctionType() == FunctionType.SOUT)
 				context.getContext().getMethodVisitor().visitFieldInsn(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;");
@@ -62,8 +61,8 @@ public class FunctionCallNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		Type[] argTypes = new Type[args.size()];
+	public WaterType getReturnType(Context context) throws SemanticException {
+		WaterType[] argTypes = new WaterType[args.size()];
 
 		for(int i = 0; i < args.size(); i++) {
 			Node arg = args.get(i);
@@ -77,7 +76,7 @@ public class FunctionCallNode implements Node {
 			if(function == null) throw new SemanticException(name,
 					"Could not resolve function '%s' with arguments: %s".formatted(name.getValue(),
 							argTypes.length == 0 ? "(none)" :
-									List.of(argTypes).stream().map(TypeUtil::stringify).collect(Collectors.joining(", "))));
+									List.of(argTypes).stream().map(WaterType::toString).collect(Collectors.joining(", "))));
 
 			return function.getType().getReturnType();
 

--- a/src/water/compiler/parser/nodes/operation/CastNode.java
+++ b/src/water/compiler/parser/nodes/operation/CastNode.java
@@ -61,17 +61,16 @@ public class CastNode implements Node {
 
 	private void stringCast(WaterType to, FileContext fc) throws SemanticException {
 		//TODO other primitives
-		//TODO Avoid getRawType() call
-		switch (to.getRawType().getSort()) {
-			case Type.INT -> {
+		switch (to.getSort()) {
+			case INT -> {
 				left.visit(fc);
 				fc.getContext().getMethodVisitor().visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Integer", "parseInt", "(Ljava/lang/String;)I", false);
 			}
-			case Type.DOUBLE -> {
+			case DOUBLE -> {
 				left.visit(fc);
 				fc.getContext().getMethodVisitor().visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Double", "parseDouble", "(Ljava/lang/String;)D", false);
 			}
-			case Type.BOOLEAN -> {
+			case BOOLEAN -> {
 				left.visit(fc);
 				fc.getContext().getMethodVisitor().visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Boolean", "parseBoolean", "(Ljava/lang/String;)Z", false);
 			}

--- a/src/water/compiler/parser/nodes/operation/IndexAccessNode.java
+++ b/src/water/compiler/parser/nodes/operation/IndexAccessNode.java
@@ -1,14 +1,13 @@
 package water.compiler.parser.nodes.operation;
 
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.LValue;
 import water.compiler.parser.Node;
-import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class IndexAccessNode implements Node {
 	private final Token bracket;
@@ -23,14 +22,14 @@ public class IndexAccessNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
-		Type leftType = left.getReturnType(context.getContext());
-		Type indexType = index.getReturnType(context.getContext());
+		WaterType leftType = left.getReturnType(context.getContext());
+		WaterType indexType = index.getReturnType(context.getContext());
 
-		if(leftType.getSort() != Type.ARRAY) {
-			throw new SemanticException(bracket, "Cannot get index of type '%s'".formatted(TypeUtil.stringify(leftType)));
+		if(!leftType.isArray()) {
+			throw new SemanticException(bracket, "Cannot get index of type '%s'".formatted(leftType));
 		}
-		if(!TypeUtil.isInteger(indexType)) {
-			throw new SemanticException(bracket, "Index must be an integer type (got '%s')".formatted(TypeUtil.stringify(indexType)));
+		if(!indexType.isInteger()) {
+			throw new SemanticException(bracket, "Index must be an integer type (got '%s')".formatted(indexType));
 		}
 
 		left.visit(context);
@@ -40,11 +39,11 @@ public class IndexAccessNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		Type leftType = left.getReturnType(context);
+	public WaterType getReturnType(Context context) throws SemanticException {
+		WaterType leftType = left.getReturnType(context);
 
-		if(leftType.getSort() != Type.ARRAY) {
-			throw new SemanticException(bracket, "Cannot get index of type '%s'".formatted(TypeUtil.stringify(leftType)));
+		if(!leftType.isArray()) {
+			throw new SemanticException(bracket, "Cannot get index of type '%s'".formatted(leftType));
 		}
 
 		return leftType.getElementType();

--- a/src/water/compiler/parser/nodes/operation/LogicalOperationNode.java
+++ b/src/water/compiler/parser/nodes/operation/LogicalOperationNode.java
@@ -3,14 +3,13 @@ package water.compiler.parser.nodes.operation;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.lexer.TokenType;
 import water.compiler.parser.Node;
-import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class LogicalOperationNode implements Node {
 
@@ -26,14 +25,14 @@ public class LogicalOperationNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
-		Type leftType = left.getReturnType(context.getContext());
-		Type rightType = right.getReturnType(context.getContext());
+		WaterType leftType = left.getReturnType(context.getContext());
+		WaterType rightType = right.getReturnType(context.getContext());
 
 		if(!verifyTypes(leftType, rightType)) {
 			throw new SemanticException(op, "Unsupported operation of '%s' between types '%s' and '%s'".formatted(
 					op.getValue(),
-					TypeUtil.stringify(leftType),
-					TypeUtil.stringify(rightType)
+					leftType,
+					rightType
 			));
 		}
 
@@ -81,14 +80,14 @@ public class LogicalOperationNode implements Node {
 	}
 
 	public boolean generateConditional(FileContext context, Label falseL) throws SemanticException {
-		Type leftType = left.getReturnType(context.getContext());
-		Type rightType = right.getReturnType(context.getContext());
+		WaterType leftType = left.getReturnType(context.getContext());
+		WaterType rightType = right.getReturnType(context.getContext());
 
 		if(!verifyTypes(leftType, rightType)) {
 			throw new SemanticException(op, "Unsupported operation of '%s' between types '%s' and '%s'".formatted(
 					op.getValue(),
-					TypeUtil.stringify(leftType),
-					TypeUtil.stringify(rightType)
+					leftType,
+					rightType
 			));
 		}
 
@@ -117,13 +116,13 @@ public class LogicalOperationNode implements Node {
 		return true;
 	}
 
-	private boolean verifyTypes(Type left, Type right) {
-		return left.getSort() == Type.BOOLEAN && right.getSort() == Type.BOOLEAN;
+	private boolean verifyTypes(WaterType left, WaterType right) {
+		return left.equals(WaterType.BOOLEAN_TYPE) && right.equals(WaterType.BOOLEAN_TYPE);
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		return Type.BOOLEAN_TYPE;
+	public WaterType getReturnType(Context context) throws SemanticException {
+		return WaterType.BOOLEAN_TYPE;
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/operation/UnaryOperationNode.java
+++ b/src/water/compiler/parser/nodes/operation/UnaryOperationNode.java
@@ -115,9 +115,8 @@ public class UnaryOperationNode implements Node {
 	public boolean isConstant(Context context) throws SemanticException {
 		if(op.getType() == TokenType.MINUS) {
 			WaterType type = expression.getReturnType(context);
-			//TODO Refactor out of getRawType
-			return switch(type.getRawType().getSort()) {
-				case Type.DOUBLE, Type.FLOAT, Type.INT, Type.LONG -> true;
+			return switch(type.getSort()) {
+				case DOUBLE, FLOAT, INT, LONG -> true;
 				default -> false;
 			};
 		}

--- a/src/water/compiler/parser/nodes/operation/UnaryOperationNode.java
+++ b/src/water/compiler/parser/nodes/operation/UnaryOperationNode.java
@@ -11,6 +11,7 @@ import water.compiler.lexer.Token;
 import water.compiler.lexer.TokenType;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class UnaryOperationNode implements Node {
 	private final Token op;
@@ -31,13 +32,13 @@ public class UnaryOperationNode implements Node {
 
 		expression.visit(context);
 
-		Type expressionType = expression.getReturnType(context.getContext());
+		WaterType expressionType = expression.getReturnType(context.getContext());
 
 		MethodVisitor mv = context.getContext().getMethodVisitor();
 
 		if(op.getType() == TokenType.EXCLAIM) {
-			if(expressionType.getSort() != Type.BOOLEAN)
-				throw new SemanticException(op, "Can only perform '!' on boolean values. (%s =/= boolean)".formatted(TypeUtil.stringify(expressionType)));
+			if(!expressionType.equals(WaterType.BOOLEAN_TYPE))
+				throw new SemanticException(op, "Can only perform '!' on boolean values. (%s =/= boolean)".formatted(expressionType));
 
 			Label falseL = new Label();
 			Label end = new Label();
@@ -50,20 +51,20 @@ public class UnaryOperationNode implements Node {
 			mv.visitLabel(end);
 		}
 		else if(op.getType() == TokenType.MINUS) {
-			if(!TypeUtil.isNumeric(expressionType)) {
-				throw new SemanticException(op, "Can only perform '-' on numeric values. (%s is not numeric)".formatted(TypeUtil.stringify(expressionType)));
+			if(!expressionType.isNumeric()) {
+				throw new SemanticException(op, "Can only perform '-' on numeric values. (%s is not numeric)".formatted(expressionType));
 			}
 
 
 			mv.visitInsn(expressionType.getOpcode(Opcodes.INEG));
 		}
 		else if(op.getType() == TokenType.BITWISE_NOT) {
-			if(!TypeUtil.isInteger(expressionType)) {
+			if(!expressionType.isInteger()) {
 				throw new SemanticException(op,
-						"Can only perform '~' on integer values. ('%s' is not an integer)".formatted(TypeUtil.stringify(expressionType)));
+						"Can only perform '~' on integer values. ('%s' is not an integer)".formatted(expressionType));
 			}
 
-			if(expressionType.getSort() == Type.LONG) {
+			if(expressionType.equals(WaterType.LONG_TYPE)) {
 				TypeUtil.generateCorrectLong(-1, context.getContext());
 				mv.visitInsn(Opcodes.LXOR);
 			}
@@ -79,18 +80,18 @@ public class UnaryOperationNode implements Node {
 		Object value = expression.getConstantValue(context);
 
 		if(op.getType() == TokenType.EXCLAIM) {
-			Type returnType = expression.getReturnType(context);
-			if(returnType.getSort() != Type.BOOLEAN)
-				throw new SemanticException(op, "Con only perform '!' on boolean values. (%s =/= boolean)".formatted(TypeUtil.stringify(returnType)));
+			WaterType returnType = expression.getReturnType(context);
+			if(!returnType.equals(WaterType.BOOLEAN_TYPE))
+				throw new SemanticException(op, "Con only perform '!' on boolean values. (%s =/= boolean)".formatted(returnType));
 
 			boolean boolVal = (Boolean) value;
 
 			return !boolVal;
 		}
 		else if(op.getType() == TokenType.MINUS) {
-			Type returnType = expression.getReturnType(context);
-			if(!TypeUtil.isNumeric(returnType)) {
-				throw new SemanticException(op, "Con only perform '-' on numeric values. (%s is not numeric)".formatted(TypeUtil.stringify(returnType)));
+			WaterType returnType = expression.getReturnType(context);
+			if(!returnType.isNumeric()) {
+				throw new SemanticException(op, "Con only perform '-' on numeric values. (%s is not numeric)".formatted(returnType));
 			}
 
 			if(value instanceof Double) {
@@ -113,8 +114,9 @@ public class UnaryOperationNode implements Node {
 	@Override
 	public boolean isConstant(Context context) throws SemanticException {
 		if(op.getType() == TokenType.MINUS) {
-			Type type = expression.getReturnType(context);
-			return switch(type.getSort()) {
+			WaterType type = expression.getReturnType(context);
+			//TODO Refactor out of getRawType
+			return switch(type.getRawType().getSort()) {
 				case Type.DOUBLE, Type.FLOAT, Type.INT, Type.LONG -> true;
 				default -> false;
 			};
@@ -124,9 +126,9 @@ public class UnaryOperationNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
+	public WaterType getReturnType(Context context) throws SemanticException {
 		return switch (op.getType()) {
-			case EXCLAIM -> Type.BOOLEAN_TYPE;
+			case EXCLAIM -> WaterType.BOOLEAN_TYPE;
 			case MINUS, BITWISE_NOT -> expression.getReturnType(context);
 			default -> throw new IllegalStateException("Unknown unary operator " + op.getType());
 		};

--- a/src/water/compiler/parser/nodes/special/ImportNode.java
+++ b/src/water/compiler/parser/nodes/special/ImportNode.java
@@ -7,6 +7,7 @@ import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class ImportNode implements Node {
 	private final Token importTok;
@@ -24,9 +25,9 @@ public class ImportNode implements Node {
 
 	@Override
 	public void preprocess(Context context) throws SemanticException {
-		Type importType = type.getReturnType(context);
+		WaterType importType = type.getReturnType(context);
 
-		if(TypeUtil.isPrimitive(importType)) {
+		if(importType.isPrimitive()) {
 			throw new SemanticException(importTok, "Cannot import primitive type");
 		}
 

--- a/src/water/compiler/parser/nodes/special/PackageNode.java
+++ b/src/water/compiler/parser/nodes/special/PackageNode.java
@@ -1,13 +1,12 @@
 package water.compiler.parser.nodes.special;
 
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
 import water.compiler.parser.nodes.value.TypeNode;
-import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class PackageNode implements Node {
 	private final Token packageNode;
@@ -24,7 +23,7 @@ public class PackageNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
+	public WaterType getReturnType(Context context) throws SemanticException {
 		return name.getRawClassType();
 	}
 

--- a/src/water/compiler/parser/nodes/statement/ExpressionStatementNode.java
+++ b/src/water/compiler/parser/nodes/statement/ExpressionStatementNode.java
@@ -7,6 +7,7 @@ import water.compiler.parser.nodes.variable.AssignmentNode;
 import water.compiler.util.OptimizationUtil;
 import water.compiler.util.TypeUtil;
 import water.compiler.parser.Node;
+import water.compiler.util.WaterType;
 
 public class ExpressionStatementNode implements Node {
 	private final Node expression;
@@ -27,7 +28,7 @@ public class ExpressionStatementNode implements Node {
 		// Optimisation - removes dup_x1 and pop instructions for assignment
 		boolean varAssign = OptimizationUtil.assignmentNodeExpressionEval(expression, context);
 
-		Type returnType = expression.getReturnType(context.getContext());
-		if(returnType.getSort() != Type.VOID && !varAssign) context.getContext().getMethodVisitor().visitInsn(TypeUtil.getPopOpcode(returnType));
+		WaterType returnType = expression.getReturnType(context.getContext());
+		if(!returnType.equals(WaterType.VOID_TYPE) && !varAssign) context.getContext().getMethodVisitor().visitInsn(returnType.getPopOpcode());
 	}
 }

--- a/src/water/compiler/parser/nodes/statement/ForStatementNode.java
+++ b/src/water/compiler/parser/nodes/statement/ForStatementNode.java
@@ -3,7 +3,6 @@ package water.compiler.parser.nodes.statement;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Scope;
 import water.compiler.compiler.SemanticException;
@@ -13,7 +12,7 @@ import water.compiler.parser.nodes.operation.EqualityOperationNode;
 import water.compiler.parser.nodes.operation.LogicalOperationNode;
 import water.compiler.parser.nodes.operation.RelativeOperationNode;
 import water.compiler.util.OptimizationUtil;
-import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class ForStatementNode implements Node {
 
@@ -33,10 +32,10 @@ public class ForStatementNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
-		Type conditionReturnType = condition.getReturnType(context.getContext());
-		if(conditionReturnType.getSort() != Type.BOOLEAN) {
+		WaterType conditionReturnType = condition.getReturnType(context.getContext());
+		if(!conditionReturnType.equals(WaterType.BOOLEAN_TYPE)) {
 			throw new SemanticException(forTok, "Invalid condition type (%s =/= boolean)"
-					.formatted(TypeUtil.stringify(conditionReturnType)));
+					.formatted(conditionReturnType));
 		}
 
 		Scope outer = context.getContext().getScope();
@@ -72,9 +71,9 @@ public class ForStatementNode implements Node {
 
 		boolean varAssign = OptimizationUtil.assignmentNodeExpressionEval(iterate, context);
 
-		Type iterateType = iterate.getReturnType(context.getContext());
+		WaterType iterateType = iterate.getReturnType(context.getContext());
 
-		if(iterateType.getSort() != Type.VOID && !varAssign) methodVisitor.visitInsn(TypeUtil.getPopOpcode(iterateType));
+		if(!iterateType.equals(WaterType.VOID_TYPE) && !varAssign) methodVisitor.visitInsn(iterateType.getPopOpcode());
 
 		methodVisitor.visitJumpInsn(Opcodes.GOTO, conditionL);
 

--- a/src/water/compiler/parser/nodes/statement/IfStatementNode.java
+++ b/src/water/compiler/parser/nodes/statement/IfStatementNode.java
@@ -3,7 +3,6 @@ package water.compiler.parser.nodes.statement;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
@@ -11,7 +10,7 @@ import water.compiler.parser.Node;
 import water.compiler.parser.nodes.operation.EqualityOperationNode;
 import water.compiler.parser.nodes.operation.LogicalOperationNode;
 import water.compiler.parser.nodes.operation.RelativeOperationNode;
-import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class IfStatementNode implements Node {
 
@@ -31,10 +30,10 @@ public class IfStatementNode implements Node {
 	public void visit(FileContext context) throws SemanticException {
 		MethodVisitor methodVisitor = context.getContext().getMethodVisitor();
 
-		Type conditionReturnType = condition.getReturnType(context.getContext());
-		if(conditionReturnType.getSort() != Type.BOOLEAN) {
+		WaterType conditionReturnType = condition.getReturnType(context.getContext());
+		if(!conditionReturnType.equals(WaterType.BOOLEAN_TYPE)) {
 			throw new SemanticException(ifTok, "Invalid condition type (%s =/= boolean)"
-					.formatted(TypeUtil.stringify(conditionReturnType)));
+					.formatted(conditionReturnType));
 		}
 
 		context.getContext().updateLine(ifTok.getLine());

--- a/src/water/compiler/parser/nodes/statement/WhileStatementNode.java
+++ b/src/water/compiler/parser/nodes/statement/WhileStatementNode.java
@@ -12,6 +12,7 @@ import water.compiler.parser.nodes.operation.EqualityOperationNode;
 import water.compiler.parser.nodes.operation.LogicalOperationNode;
 import water.compiler.parser.nodes.operation.RelativeOperationNode;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class WhileStatementNode implements Node {
 
@@ -29,10 +30,10 @@ public class WhileStatementNode implements Node {
 	public void visit(FileContext context) throws SemanticException {
 		MethodVisitor methodVisitor = context.getContext().getMethodVisitor();
 
-		Type conditionReturnType = condition.getReturnType(context.getContext());
-		if(conditionReturnType.getSort() != Type.BOOLEAN) {
+		WaterType conditionReturnType = condition.getReturnType(context.getContext());
+		if(!conditionReturnType.equals(WaterType.BOOLEAN_TYPE)) {
 			throw new SemanticException(whileTok, "Invalid condition type (%s =/= boolean)"
-					.formatted(TypeUtil.stringify(conditionReturnType)));
+					.formatted(conditionReturnType));
 		}
 
 		context.getContext().updateLine(whileTok.getLine());

--- a/src/water/compiler/parser/nodes/value/ArrayConstructorNode.java
+++ b/src/water/compiler/parser/nodes/value/ArrayConstructorNode.java
@@ -9,6 +9,7 @@ import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,19 +29,19 @@ public class ArrayConstructorNode implements Node {
 	public void visit(FileContext fileContext) throws SemanticException {
 		Context context = fileContext.getContext();
 		for(Node n : dimensions) {
-			if(!TypeUtil.isInteger(n.getReturnType(context))) {
+			if(!n.getReturnType(context).isInteger()) {
 				throw new SemanticException(newToken, "Array size must be an integer");
 			}
 			n.visit(fileContext);
 		}
 
-		Type elementType = type.getReturnType(context);
+		WaterType elementType = type.getReturnType(context);
 
 		MethodVisitor methodVisitor = context.getMethodVisitor();
 		int size = dimensions.size();
 
 		if(size == 1) {
-			if(TypeUtil.isPrimitive(elementType)) methodVisitor.visitIntInsn(Opcodes.NEWARRAY, TypeUtil.primitiveToTType(elementType));
+			if(elementType.isPrimitive()) methodVisitor.visitIntInsn(Opcodes.NEWARRAY, elementType.primitiveToTType());
 			else methodVisitor.visitTypeInsn(Opcodes.ANEWARRAY, elementType.getInternalName());
 		}
 		else {
@@ -49,8 +50,8 @@ public class ArrayConstructorNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		return Type.getType(getDescriptor(context));
+	public WaterType getReturnType(Context context) throws SemanticException {
+		return WaterType.getType(getDescriptor(context));
 	}
 
 	private String getDescriptor(Context context) throws SemanticException {

--- a/src/water/compiler/parser/nodes/value/BooleanNode.java
+++ b/src/water/compiler/parser/nodes/value/BooleanNode.java
@@ -7,6 +7,7 @@ import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
+import water.compiler.util.WaterType;
 
 public class BooleanNode implements Node {
 	private final Token value;
@@ -23,8 +24,8 @@ public class BooleanNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		return Type.BOOLEAN_TYPE;
+	public WaterType getReturnType(Context context) throws SemanticException {
+		return WaterType.BOOLEAN_TYPE;
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/value/CharNode.java
+++ b/src/water/compiler/parser/nodes/value/CharNode.java
@@ -7,6 +7,7 @@ import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class CharNode implements Node {
 
@@ -47,8 +48,8 @@ public class CharNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		return Type.CHAR_TYPE;
+	public WaterType getReturnType(Context context) throws SemanticException {
+		return WaterType.CHAR_TYPE;
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/value/GroupingNode.java
+++ b/src/water/compiler/parser/nodes/value/GroupingNode.java
@@ -6,6 +6,7 @@ import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.parser.LValue;
 import water.compiler.parser.Node;
+import water.compiler.util.WaterType;
 
 /**
  * A bracketed expression - passes through all methods.
@@ -24,7 +25,7 @@ public class GroupingNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
+	public WaterType getReturnType(Context context) throws SemanticException {
 		return value.getReturnType(context);
 	}
 

--- a/src/water/compiler/parser/nodes/value/NullNode.java
+++ b/src/water/compiler/parser/nodes/value/NullNode.java
@@ -7,6 +7,7 @@ import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class NullNode implements Node {
 	@Override
@@ -15,12 +16,12 @@ public class NullNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		return TypeUtil.OBJECT_TYPE;
+	public WaterType getReturnType(Context context) throws SemanticException {
+		return WaterType.OBJECT_TYPE;
 	}
 
 	@Override
-	public Object getConstantValue(Context context) throws SemanticException {
+	public Object getConstantValue(Context context) {
 		return null;
 	}
 

--- a/src/water/compiler/parser/nodes/value/NumberNode.java
+++ b/src/water/compiler/parser/nodes/value/NumberNode.java
@@ -1,17 +1,15 @@
 package water.compiler.parser.nodes.value;
 
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class NumberNode implements Node {
 	private final Token value;
-	private Type type;
+	private WaterType type;
 
 	public NumberNode(Token value) {
 		this.value = value;
@@ -26,31 +24,31 @@ public class NumberNode implements Node {
 	@Override
 	public void visit(FileContext context) {
 		context.getContext().updateLine(value.getLine());
-		if(type.getSort() == Type.INT) {
+		if(type.equals(WaterType.INT_TYPE)) {
 			TypeUtil.generateCorrectInt(Integer.parseInt(value.getValue()), context.getContext());
 		}
-		else if(type.getSort() == Type.DOUBLE) {
+		else if(type.equals(WaterType.DOUBLE_TYPE)) {
 			TypeUtil.generateCorrectDouble(Double.parseDouble(value.getValue()), context.getContext());
 		}
-		else if(type.getSort() == Type.FLOAT) {
+		else if(type.equals(WaterType.FLOAT_TYPE)) {
 			TypeUtil.generateCorrectFloat(Float.parseFloat(value.getValue()), context.getContext());
 		}
-		else if(type.getSort() == Type.LONG) {
+		else if(type.equals(WaterType.LONG_TYPE)) {
 			TypeUtil.generateCorrectLong(Long.parseLong(value.getValue().substring(0, value.getValue().length() - 1)), context.getContext());
 		}
 	}
 
 	@Override
-	public Type getReturnType(Context context) {
+	public WaterType getReturnType(Context context) {
 		return computeCorrectType();
 	}
 
 	@Override
 	public Object getConstantValue(Context context) {
-		if(type.getSort() == Type.INT) return Integer.parseInt(value.getValue());
-		else if(type.getSort() == Type.DOUBLE) return Double.parseDouble(value.getValue());
-		else if(type.getSort() == Type.FLOAT) return Float.parseFloat(value.getValue());
-		else if(type.getSort() == Type.LONG) return Long.parseLong(value.getValue().substring(0, value.getValue().length() - 1));
+		if(type.equals(WaterType.INT_TYPE)) return Integer.parseInt(value.getValue());
+		else if(type.equals(WaterType.DOUBLE_TYPE)) return Double.parseDouble(value.getValue());
+		else if(type.equals(WaterType.FLOAT_TYPE)) return Float.parseFloat(value.getValue());
+		else if(type.equals(WaterType.LONG_TYPE)) return Long.parseLong(value.getValue().substring(0, value.getValue().length() - 1));
 
 		return null; // Unreachable
 	}
@@ -60,12 +58,12 @@ public class NumberNode implements Node {
 		return true;
 	}
 
-	private Type computeCorrectType() {
+	private WaterType computeCorrectType() {
 		String rep = value.getValue();
 
-		if(rep.endsWith("l") || rep.endsWith("L")) return Type.LONG_TYPE;
-		if(rep.endsWith("f") || rep.endsWith("F")) return Type.FLOAT_TYPE;
-		if(rep.contains(".")) return Type.DOUBLE_TYPE;
-		return Type.INT_TYPE;
+		if(rep.endsWith("l") || rep.endsWith("L")) return WaterType.LONG_TYPE;
+		if(rep.endsWith("f") || rep.endsWith("F")) return WaterType.FLOAT_TYPE;
+		if(rep.contains(".")) return WaterType.DOUBLE_TYPE;
+		return WaterType.INT_TYPE;
 	}
 }

--- a/src/water/compiler/parser/nodes/value/StringNode.java
+++ b/src/water/compiler/parser/nodes/value/StringNode.java
@@ -1,12 +1,11 @@
 package water.compiler.parser.nodes.value;
 
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
-import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class StringNode implements Node {
 	private final Token value;
@@ -38,8 +37,8 @@ public class StringNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		return TypeUtil.STRING_TYPE;
+	public WaterType getReturnType(Context context) throws SemanticException {
+		return WaterType.STRING_TYPE;
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/value/ThisNode.java
+++ b/src/water/compiler/parser/nodes/value/ThisNode.java
@@ -1,12 +1,12 @@
 package water.compiler.parser.nodes.value;
 
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
+import water.compiler.util.WaterType;
 
 public class ThisNode implements Node {
 
@@ -27,8 +27,8 @@ public class ThisNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
-		return Type.getObjectType(context.getCurrentClass());
+	public WaterType getReturnType(Context context) throws SemanticException {
+		return WaterType.getObjectType(context.getCurrentClass());
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -7,6 +7,7 @@ import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class TypeNode implements Node {
 	private final Token root;
@@ -40,34 +41,34 @@ public class TypeNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
+	public WaterType getReturnType(Context context) throws SemanticException {
 
-		if(dimensions != 0) return Type.getType("[".repeat(dimensions) + element.getReturnType(context).getDescriptor());
+		if(dimensions != 0) return WaterType.getType("[".repeat(dimensions) + element.getReturnType(context).getDescriptor());
 
 		if(isPrimitive) return switch (root.getType()) {
-			case VOID -> Type.VOID_TYPE;
-			case INT -> Type.INT_TYPE;
-			case DOUBLE -> Type.DOUBLE_TYPE;
-			case FLOAT -> Type.FLOAT_TYPE;
-			case BOOLEAN -> Type.BOOLEAN_TYPE;
-			case CHAR -> Type.CHAR_TYPE;
-			case LONG -> Type.LONG_TYPE;
-			case BYTE -> Type.BYTE_TYPE;
-			case SHORT -> Type.SHORT_TYPE;
+			case VOID -> WaterType.VOID_TYPE;
+			case INT -> WaterType.INT_TYPE;
+			case DOUBLE -> WaterType.DOUBLE_TYPE;
+			case FLOAT -> WaterType.FLOAT_TYPE;
+			case BOOLEAN -> WaterType.BOOLEAN_TYPE;
+			case CHAR -> WaterType.CHAR_TYPE;
+			case LONG -> WaterType.LONG_TYPE;
+			case BYTE -> WaterType.BYTE_TYPE;
+			case SHORT -> WaterType.SHORT_TYPE;
 			default -> null;
 		};
 
 		try {
-			return Type.getType(TypeUtil.classForName(path, context));
+			return WaterType.getType(TypeUtil.classForName(path, context));
 		} catch (ClassNotFoundException e) {
 			throw new SemanticException(root, "Could not resolve class '%s'".formatted(e.getMessage()));
 		}
 	}
 
-	public Type getRawClassType() throws SemanticException {
+	public WaterType getRawClassType() throws SemanticException {
 		if(isPrimitive) throw new SemanticException(root, "Unexpected primitive type");
 
-		return Type.getObjectType(path.replace('.', '/'));
+		return WaterType.getObjectType(path.replace('.', '/'));
 	}
 
 	@Override

--- a/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableAccessNode.java
@@ -1,7 +1,6 @@
 package water.compiler.parser.nodes.variable;
 
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
@@ -11,6 +10,7 @@ import water.compiler.lexer.Token;
 import water.compiler.parser.LValue;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class VariableAccessNode implements Node {
 	private final Token name;
@@ -55,7 +55,7 @@ public class VariableAccessNode implements Node {
 	}
 
 	@Override
-	public Type getReturnType(Context context) throws SemanticException {
+	public WaterType getReturnType(Context context) throws SemanticException {
 		Variable v = context.getScope().lookupVariable(name.getValue());
 
 		if(v == null) {
@@ -63,7 +63,7 @@ public class VariableAccessNode implements Node {
 				try {
 					Class<?> staticClass = TypeUtil.classForName(name.getValue(), context);
 					isStaticClassAccess = true;
-					return Type.getType(staticClass);
+					return WaterType.getType(staticClass);
 				} catch (ClassNotFoundException e) {
 					throw new SemanticException(name, "Cannot resolve variable '%s' in current scope.".formatted(name.getValue()));
 				}

--- a/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
+++ b/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
@@ -8,6 +8,7 @@ import water.compiler.compiler.*;
 import water.compiler.lexer.Token;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterType;
 
 public class VariableDeclarationNode implements Node {
 
@@ -51,7 +52,7 @@ public class VariableDeclarationNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
-		Type returnType = computeExpectedType(context.getContext());
+		WaterType returnType = computeExpectedType(context.getContext());
 
 		if(context.getContext().getType() == ContextType.GLOBAL) {
 			defineGetAndSet(true, true, context.getContext());
@@ -120,7 +121,7 @@ public class VariableDeclarationNode implements Node {
 
 		String beanName = name.getValue().substring(0, 1).toUpperCase() + name.getValue().substring(1);
 
-		Type fieldType = computeExpectedType(context);
+		WaterType fieldType = computeExpectedType(context);
 		String descriptor = fieldType.getDescriptor();
 
 		// Getter
@@ -158,7 +159,7 @@ public class VariableDeclarationNode implements Node {
 		};
 	}
 
-	private Type computeExpectedType(Context context) throws SemanticException {
+	private WaterType computeExpectedType(Context context) throws SemanticException {
 		if(expectedType == null) {
 			return value.getReturnType(context);
 		}
@@ -166,14 +167,14 @@ public class VariableDeclarationNode implements Node {
 			return expectedType.getReturnType(context);
 		}
 
-		Type expected = expectedType.getReturnType(context);
-		Type valueType = value.getReturnType(context);
+		WaterType expected = expectedType.getReturnType(context);
+		WaterType valueType = value.getReturnType(context);
 
 		try {
-			if(!TypeUtil.isAssignableFrom(expected, valueType, context, false)) {
+			if(!expected.isAssignableFrom(valueType, context, false)) {
 				throw new SemanticException(name, "Cannot assign type of '%s' to annotated type of '%s'.".formatted(
-						TypeUtil.stringify(valueType),
-						TypeUtil.stringify(expected)
+						valueType,
+						expected
 				));
 			}
 		} catch (ClassNotFoundException e) {
@@ -184,7 +185,7 @@ public class VariableDeclarationNode implements Node {
 
 	private void generateValue(FileContext context) throws SemanticException {
 		if(value == null) {
-			context.getContext().getMethodVisitor().visitInsn(TypeUtil.dummyConstant(expectedType.getReturnType(context.getContext())));
+			context.getContext().getMethodVisitor().visitInsn(expectedType.getReturnType(context.getContext()).dummyConstant());
 		}
 		else {
 			value.visit(context);

--- a/src/water/compiler/util/WaterType.java
+++ b/src/water/compiler/util/WaterType.java
@@ -1,0 +1,538 @@
+package water.compiler.util;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import water.compiler.compiler.Context;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+public class WaterType {
+	private static final List<Integer> TYPE_SIZE = List.of(Type.DOUBLE, Type.FLOAT, Type.LONG, Type.INT, Type.SHORT, Type.CHAR, Type.BYTE);
+	/* constant types for utility */
+	public static WaterType BOOLEAN_TYPE = new WaterType(Type.BOOLEAN_TYPE);
+	public static WaterType BYTE_TYPE = new WaterType(Type.BYTE_TYPE);
+	public static WaterType CHAR_TYPE = new WaterType(Type.CHAR_TYPE);
+	public static WaterType DOUBLE_TYPE = new WaterType(Type.DOUBLE_TYPE);
+	public static WaterType FLOAT_TYPE = new WaterType(Type.FLOAT_TYPE);
+	public static WaterType INT_TYPE = new WaterType(Type.INT_TYPE);
+	public static WaterType LONG_TYPE = new WaterType(Type.LONG_TYPE);
+	public static WaterType SHORT_TYPE = new WaterType(Type.SHORT_TYPE);
+	public static WaterType VOID_TYPE = new WaterType(Type.VOID_TYPE);
+	/** A constant defining a Type representing the java.lang.String class */
+	public static final WaterType STRING_TYPE = WaterType.getObjectType("java/lang/String");
+	/** A constant defining a Type representing the java.lang.Object class */
+	public static final WaterType OBJECT_TYPE = WaterType.getObjectType("java/lang/Object");
+
+
+	private final Type asmType;
+
+	public WaterType(Type asmType) {
+		this.asmType = asmType;
+	}
+
+	/**
+	 * If the type is primitive - not an object, array, or method
+	 *
+	 * @return If the type is of a primitive value
+	 */
+	public boolean isPrimitive() {
+		return  asmType.getSort() != Type.OBJECT &&
+				asmType.getSort() != Type.ARRAY &&
+				asmType.getSort() != Type.METHOD;
+	}
+
+	/**
+	 *
+	 * Converts a type to the class of same type.
+	 *
+	 * Method types should not be passed to this method -> resulting in an IllegalArgumentException
+	 *
+	 * @param context The current compiler context - used for resolving the class loader
+	 * @return The Class representing the same type as the Type
+	 * @throws ClassNotFoundException Given an object type, or array type of objects, if the class cannot be found
+	 */
+	public Class<?> toClass(Context context) throws ClassNotFoundException {
+		return switch (asmType.getSort()) {
+			case Type.BOOLEAN -> boolean.class;
+			case Type.CHAR -> char.class;
+			case Type.BYTE -> byte.class;
+			case Type.SHORT -> short.class;
+			case Type.INT -> int.class;
+			case Type.FLOAT -> float.class;
+			case Type.LONG -> long.class;
+			case Type.DOUBLE -> double.class;
+			case Type.ARRAY -> getElementType().toClass(context).arrayType();
+			case Type.OBJECT -> Class.forName(getClassName(), false, context.getLoader());
+			default -> throw new IllegalArgumentException("Unexpected value: " + asmType.getSort());
+		};
+	}
+
+	/**
+	 *
+	 * Tests if two types can be implicitly cast.
+	 * For example:
+	 * int -> double returns true <br/>
+	 * double -> int returns false <br/>
+	 * Due to loss of precision
+	 *
+	 * @param from The type to attempt to cast from
+	 * @param context The current compiler context
+	 * @param convert If bytecode should be generated for conversions (such as i2d)
+	 * @return If the types can be cast implicitly
+	 * @throws ClassNotFoundException If either type represents a class which cannot be resolved
+	 */
+	public boolean isAssignableFrom(WaterType from, Context context, boolean convert) throws ClassNotFoundException {
+		//TODO Null types
+		if(isObject() && from.isObject()) {
+			return toClass(context).isAssignableFrom(from.toClass(context));
+		}
+
+		else if(isPrimitive() && from.isPrimitive()) {
+			if(TYPE_SIZE.indexOf(asmType.getSort()) <= TYPE_SIZE.indexOf(from.getRawType().getSort())) {
+				if(convert) from.cast(this, context.getMethodVisitor());
+				return true;
+			}
+			if(isRepresentedAsInteger() && from.isRepresentedAsInteger()) {
+				if(convert) from.cast(this, context.getMethodVisitor());
+				return true;
+			}
+			return false;
+		}
+
+		if(isArray() && from.isArray()) {
+			return getElementType().equals(from.getElementType());
+		}
+
+		//TODO Auto-boxing
+
+		return false;
+	}
+
+	/**
+	 * Returns how many changes / how simple the conversion between types is. Assumes the types can be cast.
+	 * @param from The type to cast from
+	 * * @return The complexity of the change
+	 */
+	public int assignChangesFrom(WaterType from) {
+		if(from.equals(this)) {
+			return 0;
+		}
+		if(isObject() && from.isObject()) {
+			return 1;
+		}
+
+		else if(isPrimitive() && from.isPrimitive()) {
+			if(TYPE_SIZE.indexOf(getRawType().getSort()) <= TYPE_SIZE.indexOf(from.getRawType().getSort())) {
+				return 1;
+			}
+			if(isRepresentedAsInteger() && from.isRepresentedAsInteger()) {
+				return 2;
+			}
+		}
+
+		if(isArray() && from.isArray()) {
+			return 0;
+		}
+
+		//TODO Auto-boxing
+
+		return -1;
+	}
+
+	/**
+	 * Auto-boxes a type to its Object wrapper.
+	 * Adds the correct bytecode to the method visitor.
+	 * @param mv The method visitor.
+	 * @return The auto-boxed object type.
+	 */
+	public WaterType autoBox(MethodVisitor mv) {
+		if(!isPrimitive()) return this;
+
+		WaterType wrapper = getAutoBoxWrapper();
+
+		autoBox(mv, wrapper);
+
+		return wrapper;
+	}
+
+	/**
+	 * Gets the auto-boxed Object type for a given type.
+	 * @return The Object wrapper type.
+	 */
+	public WaterType getAutoBoxWrapper() {
+		if(!isPrimitive()) return this;
+
+		String internalName = switch (asmType.getSort()) {
+			case Type.BOOLEAN -> "java/lang/Boolean";
+			case Type.BYTE -> "java/lang/Byte";
+			case Type.CHAR -> "java/lang/Character";
+			case Type.FLOAT -> "java/lang/Float";
+			case Type.INT -> "java/lang/Integer";
+			case Type.LONG -> "java/lang/Long";
+			case Type.SHORT -> "java/lang/Short";
+			case Type.DOUBLE -> "java/lang/Double";
+			default -> null;
+		};
+
+		return WaterType.getObjectType(internalName);
+	}
+
+	/**
+	 * Generates the bytecode to auto-box.
+	 * @param mv The method visitor.
+	 * @param wrapper The type to wrap to.
+	 */
+	private void autoBox(MethodVisitor mv, WaterType wrapper) {
+		mv.visitMethodInsn(Opcodes.INVOKESTATIC, wrapper.getInternalName(), "valueOf", "(%s)%s".formatted(getDescriptor(), wrapper.getDescriptor()), false);
+	}
+
+	/**
+	 * Converts a primitive type to the {@link org.objectweb.asm.Opcodes}.T_TYPE integer constant, for use with integer instructions.
+	 * @return The integer encoding of the type
+	 */
+	public int primitiveToTType() {
+		if(!isPrimitive()) return -1;
+
+		return switch (asmType.getSort()) {
+			case Type.BOOLEAN -> Opcodes.T_BOOLEAN;
+			case Type.CHAR -> Opcodes.T_CHAR;
+			case Type.BYTE -> Opcodes.T_BYTE;
+			case Type.SHORT -> Opcodes.T_SHORT;
+			case Type.INT -> Opcodes.T_INT;
+			case Type.LONG -> Opcodes.T_LONG;
+			case Type.FLOAT -> Opcodes.T_FLOAT;
+			case Type.DOUBLE -> Opcodes.T_DOUBLE;
+			default -> 0;
+		};
+	}
+
+	/**
+	 *
+	 * Returns an opcode to generate a 'dummy constant'.
+	 * This is a value which is used for bytecode verification expecting a value,
+	 * when the actual value is not known.
+	 *
+	 * @return The opcode of the dummy constant
+	 */
+	public int dummyConstant() {
+		return switch (asmType.getSort()) {
+			case Type.BOOLEAN, Type.CHAR, Type.BYTE, Type.SHORT, Type.INT -> Opcodes.ICONST_0;
+			case Type.LONG -> Opcodes.LCONST_0;
+			case Type.FLOAT -> Opcodes.FCONST_0;
+			case Type.DOUBLE -> Opcodes.DCONST_0;
+			default -> Opcodes.ACONST_NULL;
+		};
+	}
+
+	/**
+	 *
+	 * Generates bytecode to swap the two top values.
+	 * This bytecode differs based on the size of the types.
+	 *
+	 * @param mv The MethodVisitor to append the instructions to
+	 * @param belowTop The bottom value type
+	 */
+	public void swap(WaterType belowTop, MethodVisitor mv) {
+		if (getSize() == 1) {
+			if (belowTop.getSize() == 1) {
+				// Top = 1, below = 1
+				mv.visitInsn(Opcodes.SWAP);
+			} else {
+				// Top = 1, below = 2
+				mv.visitInsn(Opcodes.DUP_X2);
+				mv.visitInsn(Opcodes.POP);
+			}
+		} else {
+			if (belowTop.getSize() == 1) {
+				// Top = 2, below = 1
+				mv.visitInsn(Opcodes.DUP2_X1);
+			} else {
+				// Top = 2, below = 2
+				mv.visitInsn(Opcodes.DUP2_X2);
+			}
+			mv.visitInsn(Opcodes.POP2);
+		}
+	}
+
+	/**
+	 * Generates the correct bytecode for a cast (of primitives)
+	 *
+	 * Taken from ASM Commons InstructionAdapter
+	 * <a href="https://github.com/llbit/ow2-asm/blob/master/src/org/objectweb/asm/commons/InstructionAdapter.java">Github</a>
+	 *
+	 * <a href="https://github.com/llbit/ow2-asm/blob/master/LICENSE.txt">Copyright Notice</a>
+	 *
+	 * @param to The type to cast to
+	 */
+	public void cast(final WaterType to, MethodVisitor mv) {
+		if (!equals(to)) {
+			if (equals(WaterType.DOUBLE_TYPE)) {
+				if (to.equals(WaterType.FLOAT_TYPE)) {
+					mv.visitInsn(Opcodes.D2F);
+				} else if (to.equals(WaterType.LONG_TYPE)) {
+					mv.visitInsn(Opcodes.D2L);
+				} else {
+					mv.visitInsn(Opcodes.D2I);
+					WaterType.INT_TYPE.cast(to, mv);
+				}
+			} else if (equals(WaterType.FLOAT_TYPE)) {
+				if (to.equals(WaterType.DOUBLE_TYPE)) {
+					mv.visitInsn(Opcodes.F2D);
+				} else if (to.equals(WaterType.LONG_TYPE)) {
+					mv.visitInsn(Opcodes.F2L);
+				} else {
+					mv.visitInsn(Opcodes.F2I);
+					WaterType.INT_TYPE.cast(to, mv);
+				}
+			} else if (equals(WaterType.LONG_TYPE)) {
+				if (to.equals(WaterType.DOUBLE_TYPE)) {
+					mv.visitInsn(Opcodes.L2D);
+				} else if (to.equals(WaterType.FLOAT_TYPE)) {
+					mv.visitInsn(Opcodes.L2F);
+				} else {
+					mv.visitInsn(Opcodes.L2I);
+					WaterType.INT_TYPE.cast(to, mv);
+				}
+			} else {
+				if (to.equals(WaterType.BYTE_TYPE)) {
+					mv.visitInsn(Opcodes.I2B);
+				} else if (to.equals(WaterType.CHAR_TYPE)) {
+					mv.visitInsn(Opcodes.I2C);
+				} else if (to.equals(WaterType.DOUBLE_TYPE)) {
+					mv.visitInsn(Opcodes.I2D);
+				} else if (to.equals(WaterType.FLOAT_TYPE)) {
+					mv.visitInsn(Opcodes.I2F);
+				} else if (to.equals(WaterType.LONG_TYPE)) {
+					mv.visitInsn(Opcodes.I2L);
+				} else if (to.equals(WaterType.SHORT_TYPE)) {
+					mv.visitInsn(Opcodes.I2S);
+				}
+			}
+		}
+	}
+
+	/** Returns the correct opcode given a type. */
+	public int getPopOpcode() {
+		if(getSize() == 2) return Opcodes.POP2;
+		else if(getSize() == 1) return Opcodes.POP;
+		return -1;
+	}
+
+	/** Returns the correct opcode given a type. */
+	public int getDupOpcode() {
+		if(getSize() == 2) return Opcodes.DUP2;
+		else if(getSize() == 1) return Opcodes.DUP;
+		return -1;
+	}
+
+	/**
+	 * Returns the correct opcode for DUPY_X1 where Y is either 2 or not present, based on type size.
+	 * @return The correct opcode
+	 */
+	public int getDupX1Opcode() {
+		return getSize() == 2 ? Opcodes.DUP2_X1 : Opcodes.DUP_X1;
+	}
+
+	/**
+	 * Returns the correct opcode for DUPY_X2 where Y is either 2 or not present, based on type size.
+	 * @return The correct opcode
+	 */
+	public int getDupX2Opcode() {
+		return getSize() == 2 ? Opcodes.DUP2_X2 : Opcodes.DUP_X2;
+	}
+
+	/**
+	 * If the type represents an integer type - including long.
+	 * @return If the type is an integer type
+	 */
+	public boolean isInteger() {
+		return isPrimitive() && (
+						asmType.getSort() == Type.INT ||
+						asmType.getSort() == Type.BYTE ||
+						asmType.getSort() == Type.CHAR ||
+						asmType.getSort() == Type.SHORT ||
+						asmType.getSort() == Type.LONG ||
+						asmType.getSort() == Type.BOOLEAN
+		);
+	}
+	/**
+	 * If the type represents an integer type - excluding long.
+	 * @return If the type is an integer type
+	 */
+	public boolean isRepresentedAsInteger() {
+		return isPrimitive() && (
+				asmType.getSort() == Type.INT ||
+						asmType.getSort() == Type.BYTE ||
+						asmType.getSort() == Type.CHAR ||
+						asmType.getSort() == Type.SHORT ||
+						asmType.getSort() == Type.BOOLEAN
+		);
+	}
+
+	/**
+	 *
+	 * Returns if the type given is a floating point type.
+	 *
+	 * This includes double and float.
+	 *
+	 * @return If the type represents a floating point type.
+	 */
+	public boolean isFloat() {
+		return asmType.getSort() == Type.DOUBLE ||
+				asmType.getSort() == Type.FLOAT;
+	}
+
+	/**
+	 * Returns if the type is numeric - an integer type or a float type.
+	 *
+	 * @return If the type is numeric
+	 */
+	public boolean isNumeric() {
+		return isInteger() || isFloat();
+	}
+
+	/**
+	 *
+	 * Returns the 'larger' of the type types - the one with greater precision.
+	 *
+	 * The sequence is as follows: <br/>
+	 * double, float, long, int, short, char, byte
+	 *
+	 * @param right The second type to compare
+	 * @return The larger / more precise type
+	 */
+	public WaterType getLarger(WaterType right) {
+		if(TYPE_SIZE.indexOf(asmType.getSort()) < TYPE_SIZE.indexOf(right.getRawType().getSort())) return this;
+		else if(TYPE_SIZE.indexOf(asmType.getSort()) > TYPE_SIZE.indexOf(right.getRawType().getSort())) return right;
+		return this; // The same
+	}
+
+	/**
+	 * Gets the appropriate compare opcode for types double, float, and long.
+	 * Adds this opcode to the method visitor.
+	 * @param mv The method visitor to use.
+	 */
+	public void compareInit(MethodVisitor mv) {
+		switch (asmType.getSort()) {
+			case Type.DOUBLE -> mv.visitInsn(Opcodes.DCMPL);
+			case Type.FLOAT -> mv.visitInsn(Opcodes.FCMPL);
+			case Type.LONG -> mv.visitInsn(Opcodes.LCMP);
+		}
+	}
+
+	public boolean isObject() {
+		return asmType.getSort() == Type.OBJECT;
+	}
+
+	public boolean isArray() {
+		return asmType.getSort() == Type.ARRAY;
+	}
+
+	public String getInternalName() {
+		return asmType.getInternalName();
+	}
+
+	public String getClassName() {
+		return asmType.getClassName();
+	}
+
+	public WaterType getElementType() {
+		return new WaterType(asmType.getElementType());
+	}
+
+	public int getOpcode(int opcode) {
+		return asmType.getOpcode(opcode);
+	}
+
+	public int getSize() {
+		return asmType.getSize();
+	}
+
+	public WaterType[] getArgumentTypes() {
+		return Arrays.stream(asmType.getArgumentTypes()).map(WaterType::new).toArray(WaterType[]::new);
+	}
+
+	public WaterType getReturnType() {
+		return new WaterType(asmType.getReturnType());
+	}
+
+	public String getDescriptor() {
+		return asmType.getDescriptor();
+	}
+
+	public Type getRawType() {
+		return asmType;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if(!(obj instanceof WaterType)) {
+			return false;
+		}
+		WaterType other = (WaterType) obj;
+		return other.getRawType().equals(this.asmType);
+	}
+
+	@Override
+	public int hashCode() {
+		return asmType.hashCode();
+	}
+
+	/**
+	 * Converts a type to a String.
+	 * This String representation differs from Type.toString()
+	 * as it gives a standard String instead of a descriptor.
+	 *
+	 * E.g.
+	 * Type.BOOLEAN_TYPE
+	 * -> "boolean"
+	 * instead of "Z"
+	 *
+	 * @return The String representation
+	 */
+	public String toString() {
+		return switch (asmType.getSort()) {
+			case Type.VOID -> "void";
+			case Type.BOOLEAN -> "boolean";
+			case Type.CHAR -> "char";
+			case Type.BYTE -> "byte";
+			case Type.SHORT -> "short";
+			case Type.INT -> "int";
+			case Type.FLOAT -> "float";
+			case Type.LONG -> "long";
+			case Type.DOUBLE -> "double";
+			case Type.ARRAY -> new WaterType(asmType.getElementType()) + "[]";
+			case Type.OBJECT -> asmType.getClassName();
+			case Type.METHOD -> "method"; // Should not be reached
+			default -> null; // Unreachable
+		};
+	}
+
+	public static WaterType getMethodType(String descriptor) {
+		return new WaterType(Type.getMethodType(descriptor));
+	}
+
+	public static WaterType getObjectType(String internalName) {
+		return new WaterType(Type.getObjectType(internalName));
+	}
+
+	public static WaterType getType(String descriptor) {
+		return new WaterType(Type.getType(descriptor));
+	}
+
+	public static WaterType getType(Class<?> clazz) {
+		return new WaterType(Type.getType(clazz));
+	}
+
+	public static WaterType getType(Method method) {
+		return new WaterType(Type.getType(method));
+	}
+
+	public static WaterType getType(Constructor<?> constructor) {
+		return new WaterType(Type.getType(constructor));
+	}
+}

--- a/src/water/compiler/util/WaterType.java
+++ b/src/water/compiler/util/WaterType.java
@@ -27,11 +27,28 @@ public class WaterType {
 	/** A constant defining a Type representing the java.lang.Object class */
 	public static final WaterType OBJECT_TYPE = WaterType.getObjectType("java/lang/Object");
 
+	public enum Sort {
+		VOID,
+		BOOLEAN,
+		CHAR,
+		BYTE,
+		SHORT,
+		INT,
+		FLOAT,
+		LONG,
+		DOUBLE,
+		ARRAY,
+		OBJECT,
+		METHOD
+	}
+
 
 	private final Type asmType;
+	private final Sort sort;
 
 	public WaterType(Type asmType) {
 		this.asmType = asmType;
+		sort = Sort.values()[asmType.getSort()];
 	}
 
 	/**
@@ -464,7 +481,10 @@ public class WaterType {
 		return asmType.getDescriptor();
 	}
 
-	public Type getRawType() {
+	public Sort getSort() {
+		return sort;
+	}
+	private Type getRawType() {
 		return asmType;
 	}
 


### PR DESCRIPTION
Refactored all uses of ASM's type to 'WaterType'.

`WaterType` encapsulates most of TypeUtil's previous methods, such as `getPopOpcode()`.

This will allow all types to have more information about them in the future, and will improve maintainability of the compiler (imho).