### PR TITLE
Null Safety and Nullable Types

### DIFF
--- a/Compiler/src/module-info.java
+++ b/Compiler/src/module-info.java
@@ -1,5 +1,6 @@
 module water.compiler {
 	requires jcommander;
 	requires org.objectweb.asm;
+	requires water.runtime;
 	opens water.compiler to jcommander;
 }

--- a/Compiler/src/water/compiler/compiler/Context.java
+++ b/Compiler/src/water/compiler/compiler/Context.java
@@ -34,6 +34,7 @@ public class Context {
 	private boolean isConstructor;
 	private int currentLine;
 	private List<VariableDeclarationNode> classVariables;
+	private Label nullJumpLabel;
 
 	public Context() {
 		this.imports = new HashMap<>();
@@ -165,6 +166,14 @@ public class Context {
 
 	public ClassWriter getCurrentClassWriter() {
 		return classWriterMap.get(currentClass);
+	}
+
+	public Label getNullJumpLabel(Label other) {
+		return nullJumpLabel == null ? other : nullJumpLabel;
+	}
+
+	public void setNullJumpLabel(Label nullJumpLabel) {
+		this.nullJumpLabel = nullJumpLabel;
 	}
 
 	private void initImports() {

--- a/Compiler/src/water/compiler/compiler/Scope.java
+++ b/Compiler/src/water/compiler/compiler/Scope.java
@@ -34,15 +34,7 @@ public class Scope {
 		this.localIndex = 0;
 		this.returnType = WaterType.VOID_TYPE;
 
-		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("()V")));
-		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(D)V")));
-		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(F)V")));
-		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(I)V")));
-		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(Z)V")));
-		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(C)V")));
-		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(J)V")));
-		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(Ljava/lang/Object;)V")));
-
+		addPrintlnFunctions();
 		updateCurrentClassMethods(context);
 	}
 
@@ -51,6 +43,10 @@ public class Scope {
 		this.functionMap = new HashMap<>();
 		this.variables = new HashMap<>();
 
+		addPrintlnFunctions();
+	}
+
+	private void addPrintlnFunctions() {
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("()V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(D)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(F)V")));
@@ -58,7 +54,7 @@ public class Scope {
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(Z)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(C)V")));
 		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(J)V")));
-		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType("(Ljava/lang/Object;)V")));
+		addFunction(new Function(FunctionType.SOUT, "println", "java/io/PrintStream", WaterType.getMethodType(WaterType.VOID_TYPE, WaterType.NULLABLE_OBJECT_TYPE)));
 	}
 
 	private Scope() {}

--- a/Compiler/src/water/compiler/lexer/Lexer.java
+++ b/Compiler/src/water/compiler/lexer/Lexer.java
@@ -107,7 +107,7 @@ public class Lexer {
 					case '|' -> next('|') ? TokenType.LOGICAL_OR : next('=') ? TokenType.IN_BITWISE_OR : TokenType.BITWISE_OR;
 					case '^' -> next('=') ? TokenType.IN_BITWISE_XOR : TokenType.BITWISE_XOR;
 					case '~' -> TokenType.BITWISE_NOT;
-					case '?' -> TokenType.QUESTION;
+					case '?' -> next('.') ? TokenType.QUESTION_DOT : TokenType.QUESTION;
 					default -> TokenType.ERROR;
 				};
 				token = makeToken(type);

--- a/Compiler/src/water/compiler/lexer/Lexer.java
+++ b/Compiler/src/water/compiler/lexer/Lexer.java
@@ -107,7 +107,7 @@ public class Lexer {
 					case '|' -> next('|') ? TokenType.LOGICAL_OR : next('=') ? TokenType.IN_BITWISE_OR : TokenType.BITWISE_OR;
 					case '^' -> next('=') ? TokenType.IN_BITWISE_XOR : TokenType.BITWISE_XOR;
 					case '~' -> TokenType.BITWISE_NOT;
-					case '?' -> next('.') ? TokenType.QUESTION_DOT : TokenType.QUESTION;
+					case '?' -> question();
 					default -> TokenType.ERROR;
 				};
 				token = makeToken(type);
@@ -118,6 +118,18 @@ public class Lexer {
 		tokens.add(makeToken(TokenType.EOF));
 
 		return tokens;
+	}
+
+	/** Matches against different token types which begin with '?' */
+	private TokenType question() {
+		if(next('.')) {
+			return TokenType.QUESTION_DOT;
+		}
+		else if(next('[')) {
+			return TokenType.QUESTION_LSQBR;
+		}
+
+		return TokenType.QUESTION;
 	}
 
 	/** Matches against different tokens which start with '>' */

--- a/Compiler/src/water/compiler/lexer/Lexer.java
+++ b/Compiler/src/water/compiler/lexer/Lexer.java
@@ -128,6 +128,9 @@ public class Lexer {
 		else if(next('[')) {
 			return TokenType.QUESTION_LSQBR;
 		}
+		else if(next('?')) {
+			return TokenType.QUESTION_QUESTION;
+		}
 
 		return TokenType.QUESTION;
 	}

--- a/Compiler/src/water/compiler/lexer/Lexer.java
+++ b/Compiler/src/water/compiler/lexer/Lexer.java
@@ -107,6 +107,7 @@ public class Lexer {
 					case '|' -> next('|') ? TokenType.LOGICAL_OR : next('=') ? TokenType.IN_BITWISE_OR : TokenType.BITWISE_OR;
 					case '^' -> next('=') ? TokenType.IN_BITWISE_XOR : TokenType.BITWISE_XOR;
 					case '~' -> TokenType.BITWISE_NOT;
+					case '?' -> TokenType.QUESTION;
 					default -> TokenType.ERROR;
 				};
 				token = makeToken(type);

--- a/Compiler/src/water/compiler/lexer/TokenType.java
+++ b/Compiler/src/water/compiler/lexer/TokenType.java
@@ -31,6 +31,7 @@ public enum TokenType {
 	BITWISE_SHL,
 	BITWISE_SHR,
 	BITWISE_USHR,
+	QUESTION_DOT,
 
 	// Inplace
 	IN_PLUS,

--- a/Compiler/src/water/compiler/lexer/TokenType.java
+++ b/Compiler/src/water/compiler/lexer/TokenType.java
@@ -19,6 +19,7 @@ public enum TokenType {
 	BITWISE_OR,
 	BITWISE_XOR,
 	BITWISE_NOT,
+	QUESTION,
 
 	// Multi character
 	ARROW,

--- a/Compiler/src/water/compiler/lexer/TokenType.java
+++ b/Compiler/src/water/compiler/lexer/TokenType.java
@@ -33,6 +33,7 @@ public enum TokenType {
 	BITWISE_USHR,
 	QUESTION_DOT,
 	QUESTION_LSQBR,
+	QUESTION_QUESTION,
 
 	// Inplace
 	IN_PLUS,

--- a/Compiler/src/water/compiler/lexer/TokenType.java
+++ b/Compiler/src/water/compiler/lexer/TokenType.java
@@ -32,6 +32,7 @@ public enum TokenType {
 	BITWISE_SHR,
 	BITWISE_USHR,
 	QUESTION_DOT,
+	QUESTION_LSQBR,
 
 	// Inplace
 	IN_PLUS,

--- a/Compiler/src/water/compiler/parser/LValue.java
+++ b/Compiler/src/water/compiler/parser/LValue.java
@@ -4,5 +4,6 @@ public enum LValue {
 	NONE,
 	VARIABLE,
 	PROPERTY,
-	ARRAY
+	ARRAY,
+	NULLABLE_PROPERTY
 }

--- a/Compiler/src/water/compiler/parser/Parser.java
+++ b/Compiler/src/water/compiler/parser/Parser.java
@@ -13,6 +13,7 @@ import water.compiler.parser.nodes.function.FunctionCallNode;
 import water.compiler.parser.nodes.function.FunctionDeclarationNode;
 import water.compiler.parser.nodes.nullability.NonNullAssertionNode;
 import water.compiler.parser.nodes.nullability.NullableMemberAccessNode;
+import water.compiler.parser.nodes.nullability.NullableMethodCallNode;
 import water.compiler.parser.nodes.operation.*;
 import water.compiler.parser.nodes.special.ImportNode;
 import water.compiler.parser.nodes.special.PackageNode;
@@ -656,7 +657,7 @@ public class Parser {
 			if(tokens.get(index).getType() == TokenType.LPAREN) {
 				List<Node> args = arguments("method arguments");
 
-				left = new MethodCallNode(left, name, args, false);
+				left = nullable ? new NullableMethodCallNode(left, name, args, false) : new MethodCallNode(left, name, args, false);
 			}
 			else {
 				left = nullable ? new NullableMemberAccessNode(left, name) : new MemberAccessNode(left, name);

--- a/Compiler/src/water/compiler/parser/Parser.java
+++ b/Compiler/src/water/compiler/parser/Parser.java
@@ -737,9 +737,9 @@ public class Parser {
 
 	//============================ Utility ============================
 
-	/** Forms grammar: basicType('[' ']')* */
+	/** Forms grammar: basicType('[' ']')*(\?)? */
 	private Node type() throws UnexpectedTokenException {
-		Node type = basicType();
+		TypeNode type = basicType();
 
 		int dim = 0;
 		while(match(TokenType.LSQBR)) {
@@ -747,14 +747,17 @@ public class Parser {
 			dim++;
 		}
 
+		boolean isNullable = match(TokenType.QUESTION);
+
 		if(dim != 0) {
-			type = new TypeNode((TypeNode) type, dim);
+			type = new TypeNode(type, dim);
 		}
+		type.setNullable(isNullable);
 
 		return type;
 	}
 
-	private Node basicType() throws UnexpectedTokenException {
+	private TypeNode basicType() throws UnexpectedTokenException {
 		if(Lexer.PRIMITIVE_TYPES.contains(tokens.get(index).getType())) {
 			return new TypeNode(advance());
 		}
@@ -764,7 +767,7 @@ public class Parser {
 	}
 
 	/** Forms grammar: IDENTIFIER ('.' IDENTIFIER)* */
-	private Node classType() throws UnexpectedTokenException {
+	private TypeNode classType() throws UnexpectedTokenException {
 		ArrayList<String> parts = new ArrayList<>();
 		Token start = tokens.get(index);
 		do {

--- a/Compiler/src/water/compiler/parser/Parser.java
+++ b/Compiler/src/water/compiler/parser/Parser.java
@@ -1,6 +1,5 @@
 package water.compiler.parser;
 
-import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Lexer;
 import water.compiler.lexer.Token;
 import water.compiler.lexer.TokenType;
@@ -12,6 +11,7 @@ import water.compiler.parser.nodes.exception.ThrowNode;
 import water.compiler.parser.nodes.exception.TryNode;
 import water.compiler.parser.nodes.function.FunctionCallNode;
 import water.compiler.parser.nodes.function.FunctionDeclarationNode;
+import water.compiler.parser.nodes.nullability.NonNullAssertionNode;
 import water.compiler.parser.nodes.operation.*;
 import water.compiler.parser.nodes.special.ImportNode;
 import water.compiler.parser.nodes.special.PackageNode;
@@ -632,9 +632,13 @@ public class Parser {
 		return memberAccess();
 	}
 
-	/** Forms grammar: atom (('.' IDENTIFIER arguments?) | ('[' expression ']'))* */
+	/** Forms grammar: atom(!)? (('.' IDENTIFIER arguments?) | ('[' expression ']'))* */
 	private Node memberAccess() throws UnexpectedTokenException {
 		Node left = atom();
+
+		if(match(TokenType.EXCLAIM)) {
+			left = new NonNullAssertionNode(left, tokens.get(index - 1));
+		}
 
 		while(match(TokenType.DOT) || match(TokenType.LSQBR)) {
 			if(tokens.get(index - 1).getType() == TokenType.LSQBR) {

--- a/Compiler/src/water/compiler/parser/Parser.java
+++ b/Compiler/src/water/compiler/parser/Parser.java
@@ -12,6 +12,7 @@ import water.compiler.parser.nodes.exception.TryNode;
 import water.compiler.parser.nodes.function.FunctionCallNode;
 import water.compiler.parser.nodes.function.FunctionDeclarationNode;
 import water.compiler.parser.nodes.nullability.NonNullAssertionNode;
+import water.compiler.parser.nodes.nullability.NullableMemberAccessNode;
 import water.compiler.parser.nodes.operation.*;
 import water.compiler.parser.nodes.special.ImportNode;
 import water.compiler.parser.nodes.special.PackageNode;
@@ -632,7 +633,7 @@ public class Parser {
 		return memberAccess();
 	}
 
-	/** Forms grammar: atom(!)? (('.' IDENTIFIER arguments?) | ('[' expression ']'))* */
+	/** Forms grammar: atom(!)? ((('.' | '?.') IDENTIFIER arguments?) | ('[' expression ']'))* */
 	private Node memberAccess() throws UnexpectedTokenException {
 		Node left = atom();
 
@@ -640,7 +641,7 @@ public class Parser {
 			left = new NonNullAssertionNode(left, tokens.get(index - 1));
 		}
 
-		while(match(TokenType.DOT) || match(TokenType.LSQBR)) {
+		while(match(TokenType.DOT) || match(TokenType.QUESTION_DOT) || match(TokenType.LSQBR)) {
 			if(tokens.get(index - 1).getType() == TokenType.LSQBR) {
 				Token bracket = tokens.get(index - 1);
 				Node index = expression();
@@ -649,6 +650,7 @@ public class Parser {
 				continue;
 			}
 
+			boolean nullable = tokens.get(index - 1).getType() == TokenType.QUESTION_DOT;
 			Token name = consume(TokenType.IDENTIFIER, "Expected member name");
 
 			if(tokens.get(index).getType() == TokenType.LPAREN) {
@@ -657,7 +659,7 @@ public class Parser {
 				left = new MethodCallNode(left, name, args, false);
 			}
 			else {
-				left = new MemberAccessNode(left, name);
+				left = nullable ? new NullableMemberAccessNode(left, name) : new MemberAccessNode(left, name);
 			}
 		}
 

--- a/Compiler/src/water/compiler/parser/Parser.java
+++ b/Compiler/src/water/compiler/parser/Parser.java
@@ -12,6 +12,7 @@ import water.compiler.parser.nodes.exception.TryNode;
 import water.compiler.parser.nodes.function.FunctionCallNode;
 import water.compiler.parser.nodes.function.FunctionDeclarationNode;
 import water.compiler.parser.nodes.nullability.NonNullAssertionNode;
+import water.compiler.parser.nodes.nullability.NullableIndexAccessNode;
 import water.compiler.parser.nodes.nullability.NullableMemberAccessNode;
 import water.compiler.parser.nodes.nullability.NullableMethodCallNode;
 import water.compiler.parser.nodes.operation.*;
@@ -642,12 +643,19 @@ public class Parser {
 			left = new NonNullAssertionNode(left, tokens.get(index - 1));
 		}
 
-		while(match(TokenType.DOT) || match(TokenType.QUESTION_DOT) || match(TokenType.LSQBR)) {
+		while(match(TokenType.DOT) || match(TokenType.QUESTION_DOT) || match(TokenType.LSQBR) || match(TokenType.QUESTION_LSQBR)) {
 			if(tokens.get(index - 1).getType() == TokenType.LSQBR) {
 				Token bracket = tokens.get(index - 1);
 				Node index = expression();
 				consume(TokenType.RSQBR, "Expected ']' after index");
 				left = new IndexAccessNode(bracket, left, index);
+				continue;
+			}
+			else if(tokens.get(index - 1).getType() == TokenType.QUESTION_LSQBR) {
+				Token bracket = tokens.get(index - 1);
+				Node index = expression();
+				consume(TokenType.RSQBR, "Expected ']' after index");
+				left = new NullableIndexAccessNode(bracket, left, index);
 				continue;
 			}
 

--- a/Compiler/src/water/compiler/parser/Parser.java
+++ b/Compiler/src/water/compiler/parser/Parser.java
@@ -764,22 +764,32 @@ public class Parser {
 
 	//============================ Utility ============================
 
-	/** Forms grammar: basicType('[' ']')*(\?)? */
+	/** Forms grammar: basicType(\?)?(('[' ']')* (\?)?)? */
 	private Node type() throws UnexpectedTokenException {
 		TypeNode type = basicType();
 
 		int dim = 0;
+
+		if(match(TokenType.QUESTION)) {
+			type.setNullable(true);
+		}
+		else if(match(TokenType.QUESTION_LSQBR)) {
+			type.setNullable(true);
+			dim++;
+			consume(TokenType.RSQBR, "Expected closing ']'");
+		}
+
 		while(match(TokenType.LSQBR)) {
 			consume(TokenType.RSQBR, "Expected closing ']'");
 			dim++;
 		}
 
-		boolean isNullable = match(TokenType.QUESTION);
-
 		if(dim != 0) {
 			type = new TypeNode(type, dim);
+			if(match(TokenType.QUESTION)) {
+				type.setNullable(true);
+			}
 		}
-		type.setNullable(isNullable);
 
 		return type;
 	}

--- a/Compiler/src/water/compiler/parser/nodes/block/ProgramNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/block/ProgramNode.java
@@ -10,6 +10,7 @@ import water.compiler.compiler.SemanticException;
 import water.compiler.parser.Node;
 import water.compiler.parser.nodes.classes.ClassDeclarationNode;
 import water.compiler.parser.nodes.variable.VariableDeclarationNode;
+import water.compiler.util.WaterClassWriter;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -133,7 +134,7 @@ public class ProgramNode implements Node {
 
 		context.setCurrentClass(name);
 
-		ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+		ClassWriter writer = new WaterClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES, context.getLoader());
 
 		writer.visit(Opcodes.V9, Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SUPER, name, null, "java/lang/Object", null);
 

--- a/Compiler/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/classes/ClassDeclarationNode.java
@@ -12,6 +12,7 @@ import water.compiler.lexer.Token;
 import water.compiler.lexer.TokenType;
 import water.compiler.parser.Node;
 import water.compiler.parser.nodes.variable.VariableDeclarationNode;
+import water.compiler.util.WaterClassWriter;
 import water.compiler.util.WaterType;
 
 import java.lang.reflect.Constructor;
@@ -197,7 +198,7 @@ public class ClassDeclarationNode implements Node {
 
 		context.setCurrentClass(className);
 
-		ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+		ClassWriter writer = new WaterClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES, context.getLoader());
 
 		writer.visit(Opcodes.V9, accessLevel | Opcodes.ACC_SUPER, className, null, superclassName, null);
 

--- a/Compiler/src/water/compiler/parser/nodes/classes/EnumDeclarationNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/classes/EnumDeclarationNode.java
@@ -12,6 +12,7 @@ import water.compiler.lexer.Token;
 import water.compiler.lexer.TokenType;
 import water.compiler.parser.Node;
 import water.compiler.util.TypeUtil;
+import water.compiler.util.WaterClassWriter;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -154,7 +155,7 @@ public class EnumDeclarationNode implements Node {
 
 		context.setCurrentClass(className);
 
-		ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+		ClassWriter writer = new WaterClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES, context.getLoader());
 
 		writer.visit(Opcodes.V9, accessLevel | Opcodes.ACC_SUPER | Opcodes.ACC_FINAL | Opcodes.ACC_ENUM, className, "Ljava/lang/Enum<L%s;>;".formatted(className), "java/lang/Enum", null);
 

--- a/Compiler/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
@@ -30,6 +30,7 @@ public class MemberAccessNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
+		getLeftType(context.getContext()); // Initializes the variable access node to a static state (if in a static access)
 		left.visit(context);
 
 		WaterType returnType = left.getReturnType(context.getContext());

--- a/Compiler/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/classes/MemberAccessNode.java
@@ -123,7 +123,7 @@ public class MemberAccessNode implements Node {
 	private WaterType attemptMethodCall(Class<?> klass, WaterType leftType, String methodName, boolean generate, Context context) throws NoSuchMethodException, SemanticException {
 		Method m = klass.getMethod(methodName);
 
-		WaterType returnType = WaterType.getType(m.getReturnType());
+		WaterType returnType = WaterType.getType(m).getReturnType();
 
 		if(!isStaticAccess && Modifier.isStatic(m.getModifiers())) {
 			throw new SemanticException(name, "Cannot access static member from non-static object.");

--- a/Compiler/src/water/compiler/parser/nodes/classes/MethodCallNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/classes/MethodCallNode.java
@@ -40,10 +40,15 @@ public class MethodCallNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
+		left.visit(context);
+
+		visitCall(context);
+	}
+
+	public void visitCall(FileContext context) throws SemanticException {
 		WaterType leftType = getLeftType(context.getContext());
 
 		if(leftType.isArray() && name.getValue().equals("length") && args.size() == 0) {
-			left.visit(context);
 			context.getContext().getMethodVisitor().visitInsn(Opcodes.ARRAYLENGTH);
 			return;
 		}
@@ -51,8 +56,6 @@ public class MethodCallNode implements Node {
 		if(!leftType.isObject()) {
 			throw new SemanticException(name, "Cannot invoke method on type '%s'".formatted(leftType));
 		}
-
-		left.visit(context);
 
 		Method toCall = resolve(leftType, context.getContext());
 
@@ -76,7 +79,6 @@ public class MethodCallNode implements Node {
 				.formatted(paramTypes.map(WaterType::getDescriptor).collect(Collectors.joining()), Type.getType(toCall.getReturnType()).getDescriptor());
 
 		context.getContext().getMethodVisitor().visitMethodInsn(isSuper ? Opcodes.INVOKESPECIAL : TypeUtil.getInvokeOpcode(toCall), leftType.getInternalName(), name.getValue(), descriptor, false);
-
 	}
 
 	@Override

--- a/Compiler/src/water/compiler/parser/nodes/classes/MethodCallNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/classes/MethodCallNode.java
@@ -40,6 +40,7 @@ public class MethodCallNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
+		getLeftType(context.getContext()); // Initializes the variable access node to a static state (if in a static access)
 		left.visit(context);
 
 		WaterType returnType = left.getReturnType(context.getContext());

--- a/Compiler/src/water/compiler/parser/nodes/classes/MethodCallNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/classes/MethodCallNode.java
@@ -42,6 +42,11 @@ public class MethodCallNode implements Node {
 	public void visit(FileContext context) throws SemanticException {
 		left.visit(context);
 
+		WaterType returnType = left.getReturnType(context.getContext());
+		if(returnType.isNullable()) {
+			throw new SemanticException(name, "Cannot use '.' to call methods on a nullable type ('%s')".formatted(returnType));
+		}
+
 		visitCall(context);
 	}
 

--- a/Compiler/src/water/compiler/parser/nodes/classes/MethodCallNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/classes/MethodCallNode.java
@@ -93,7 +93,7 @@ public class MethodCallNode implements Node {
 
 		if(leftType.isArray() && name.getValue().equals("length") && args.size() == 0) return WaterType.INT_TYPE;
 
-		return WaterType.getType(resolve(leftType, context).getReturnType());
+		return WaterType.getType(resolve(leftType, context)).getReturnType();
 	}
 
 	private WaterType getLeftType(Context context) throws SemanticException {

--- a/Compiler/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
@@ -79,7 +79,7 @@ public class FunctionDeclarationNode implements Node {
 		}
 
 		MethodVisitor mv = makeGlobalFunction(context);
-		finalizeMethod(mv);
+		finalizeMethod(mv, context);
 
 		context.getScope().addFunction(new Function(FunctionType.STATIC, name.getValue(), context.getCurrentClass(), WaterType.getMethodType(descriptor)));
 	}
@@ -111,7 +111,7 @@ public class FunctionDeclarationNode implements Node {
 		}
 
 		MethodVisitor mv = makeClassFunction(context);
-		finalizeMethod(mv);
+		finalizeMethod(mv, context);
 
 		context.getScope().addFunction(new Function(FunctionType.CLASS, name.getValue(), context.getCurrentClass(), WaterType.getMethodType(descriptor)));
 	}
@@ -124,6 +124,8 @@ public class FunctionDeclarationNode implements Node {
 		else mv = makeClassFunction(context.getContext());
 		createMainMethod(context.getContext());
 		mv.visitCode();
+
+		addNullableAnnotations(mv, context.getContext());
 
 		context.getContext().setMethodVisitor(mv);
 
@@ -175,14 +177,34 @@ public class FunctionDeclarationNode implements Node {
 		return context.getCurrentClassWriter().visitMethod(access | staticAccess, name.getValue(), descriptor, null, exceptions);
 	}
 
-	private void finalizeMethod(MethodVisitor mv) {
+	private void finalizeMethod(MethodVisitor mv, Context context) throws SemanticException {
 		mv.visitCode();
+
+		addNullableAnnotations(mv, context);
 
 		if(!returnType.equals(WaterType.VOID_TYPE)) mv.visitInsn(returnType.dummyConstant());
 		mv.visitInsn(returnType.getOpcode(Opcodes.IRETURN));
 
 		mv.visitMaxs(0, 0);
 		mv.visitEnd();
+	}
+
+	private void addNullableAnnotations(MethodVisitor visitor, Context context) throws SemanticException {
+		if(returnType.isNullable()) {
+			visitor.visitAnnotation("Lwater/runtime/annotation/Nullable;", false);
+		}
+
+		int nullableParameterCount = (int) parameters.stream().map(Pair::getSecond).map(n -> Unthrow.wrap(() -> n.getReturnType(context)))
+				.filter(WaterType::isNullable).count();
+
+		visitor.visitAnnotableParameterCount(nullableParameterCount, false);
+
+		for(int i = 0; i < parameters.size(); i++) {
+			WaterType parameterType = parameters.get(i).getSecond().getReturnType(context);
+			if(parameterType.isNullable()) {
+				visitor.visitParameterAnnotation(i, "Lwater/runtime/annotation/Nullable;", false);
+			}
+		}
 	}
 
 	private void makeDescriptor(Context context) {

--- a/Compiler/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/function/FunctionDeclarationNode.java
@@ -191,18 +191,18 @@ public class FunctionDeclarationNode implements Node {
 
 	private void addNullableAnnotations(MethodVisitor visitor, Context context) throws SemanticException {
 		if(returnType.isNullable()) {
-			visitor.visitAnnotation("Lwater/runtime/annotation/Nullable;", false);
+			visitor.visitAnnotation("Lwater/runtime/annotation/Nullable;", true);
 		}
 
 		int nullableParameterCount = (int) parameters.stream().map(Pair::getSecond).map(n -> Unthrow.wrap(() -> n.getReturnType(context)))
 				.filter(WaterType::isNullable).count();
 
-		visitor.visitAnnotableParameterCount(nullableParameterCount, false);
+		visitor.visitAnnotableParameterCount(nullableParameterCount, true);
 
 		for(int i = 0; i < parameters.size(); i++) {
 			WaterType parameterType = parameters.get(i).getSecond().getReturnType(context);
 			if(parameterType.isNullable()) {
-				visitor.visitParameterAnnotation(i, "Lwater/runtime/annotation/Nullable;", false);
+				visitor.visitParameterAnnotation(i, "Lwater/runtime/annotation/Nullable;", true);
 			}
 		}
 	}

--- a/Compiler/src/water/compiler/parser/nodes/nullability/LogicalNullOperatorNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/nullability/LogicalNullOperatorNode.java
@@ -1,0 +1,71 @@
+package water.compiler.parser.nodes.nullability;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import water.compiler.FileContext;
+import water.compiler.compiler.Context;
+import water.compiler.compiler.SemanticException;
+import water.compiler.lexer.Token;
+import water.compiler.parser.Node;
+import water.compiler.util.WaterType;
+
+public class LogicalNullOperatorNode implements Node {
+
+	private final Node left;
+	private final Token op;
+	private final Node right;
+
+	public LogicalNullOperatorNode(Node left, Token op, Node right) {
+		this.left = left;
+		this.op = op;
+		this.right = right;
+	}
+
+	@Override
+	public void visit(FileContext context) throws SemanticException {
+		WaterType leftType = left.getReturnType(context.getContext());
+
+		if(!leftType.isNullable() || leftType.isPrimitive()) {
+			throw new SemanticException(op, "Cannot perform '??' on a non-nullable type ('%s')".formatted(leftType));
+		}
+
+		left.visit(context);
+
+		Label end = new Label();
+
+		context.getContext().getMethodVisitor().visitInsn(leftType.getDupOpcode());
+		context.getContext().getMethodVisitor().visitJumpInsn(Opcodes.IFNONNULL, end);
+
+		context.getContext().getMethodVisitor().visitInsn(leftType.getPopOpcode());
+		right.visit(context);
+
+		context.getContext().getMethodVisitor().visitLabel(end);
+	}
+
+	@Override
+	public WaterType getReturnType(Context context) throws SemanticException {
+		WaterType leftType = left.getReturnType(context);
+		WaterType rightType = right.getReturnType(context);
+
+		if(!leftType.isNullable() || leftType.isPrimitive()) {
+			throw new SemanticException(op, "Cannot perform '??' on a non-nullable type ('%s')".formatted(leftType));
+		}
+
+		WaterType nonNullableLeft = leftType.asNonNullable();
+
+		try {
+			if(!nonNullableLeft.isAssignableFrom(rightType, context, false)) {
+				throw new SemanticException(op, "Cannot perform '??' on types '%s' and '%s'".formatted(leftType, rightType));
+			}
+		} catch (ClassNotFoundException e) {
+			throw new SemanticException(op, "Cannot resolve class '%s'".formatted(e.getMessage()));
+		}
+
+		return nonNullableLeft;
+	}
+
+	@Override
+	public String toString() {
+		return "%s ?? %s".formatted(left, right);
+	}
+}

--- a/Compiler/src/water/compiler/parser/nodes/nullability/NonNullAssertionNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/nullability/NonNullAssertionNode.java
@@ -1,0 +1,72 @@
+package water.compiler.parser.nodes.nullability;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import water.compiler.FileContext;
+import water.compiler.compiler.Context;
+import water.compiler.compiler.SemanticException;
+import water.compiler.lexer.Token;
+import water.compiler.parser.Node;
+import water.compiler.util.WaterType;
+
+public class NonNullAssertionNode implements Node {
+
+	private final Node target;
+	private final Token op;
+
+	public NonNullAssertionNode(Node target, Token op) {
+		this.target = target;
+		this.op = op;
+	}
+
+	@Override
+	public void visit(FileContext context) throws SemanticException {
+		target.visit(context);
+
+		WaterType returnType = target.getReturnType(context.getContext());
+		if(returnType.isPrimitive()) {
+			throw new SemanticException(op, "Cannot assert non-null on primitive type '%s'".formatted(returnType));
+		}
+		if(!returnType.isNullable()) {
+			throw new SemanticException(op, "Cannot assert non-null on type which is already not null ('%s')".formatted(returnType));
+		}
+
+		MethodVisitor visitor = context.getContext().getMethodVisitor();
+
+		visitor.visitInsn(returnType.getDupOpcode());
+
+		Label nonNullBranch = new Label();
+
+		visitor.visitJumpInsn(Opcodes.IFNONNULL, nonNullBranch);
+
+		// Create NPE
+		visitor.visitTypeInsn(Opcodes.NEW, "java/lang/NullPointerException");
+		visitor.visitInsn(Opcodes.DUP);
+		visitor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/NullPointerException", "<init>", "()V", false);
+
+		// Throw
+		visitor.visitInsn(Opcodes.ATHROW);
+
+		visitor.visitLabel(nonNullBranch);
+	}
+
+	@Override
+	public WaterType getReturnType(Context context) throws SemanticException {
+		WaterType type = target.getReturnType(context);
+
+		if(type.isPrimitive()) {
+			throw new SemanticException(op, "Cannot assert non-null on primitive type '%s'".formatted(type));
+		}
+		if(!type.isNullable()) {
+			throw new SemanticException(op, "Cannot assert non-null on type which is already not null ('%s')".formatted(type));
+		}
+
+		return type.copy().setNullable(false);
+	}
+
+	@Override
+	public String toString() {
+		return target + "!";
+	}
+}

--- a/Compiler/src/water/compiler/parser/nodes/nullability/NonNullAssertionNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/nullability/NonNullAssertionNode.java
@@ -62,7 +62,7 @@ public class NonNullAssertionNode implements Node {
 			throw new SemanticException(op, "Cannot assert non-null on type which is already not null ('%s')".formatted(type));
 		}
 
-		return type.copy().setNullable(false);
+		return type.copy().asNonNullable();
 	}
 
 	@Override

--- a/Compiler/src/water/compiler/parser/nodes/nullability/NullableIndexAccessNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/nullability/NullableIndexAccessNode.java
@@ -30,10 +30,21 @@ public class NullableIndexAccessNode implements Node {
 		}
 
 		Label nullValue = new Label();
+
+		boolean isSettingJump = false;
+		if(context.getContext().getNullJumpLabel(nullValue) == nullValue) {
+			context.getContext().setNullJumpLabel(nullValue);
+			isSettingJump = true;
+		}
+
 		left.visit(context);
 
+		if(isSettingJump) {
+			context.getContext().setNullJumpLabel(null);
+		}
+
 		context.getContext().getMethodVisitor().visitInsn(Opcodes.DUP);
-		context.getContext().getMethodVisitor().visitJumpInsn(Opcodes.IFNULL, nullValue);
+		context.getContext().getMethodVisitor().visitJumpInsn(Opcodes.IFNULL, context.getContext().getNullJumpLabel(nullValue));
 
 		synthetic().visitAccess(context);
 

--- a/Compiler/src/water/compiler/parser/nodes/nullability/NullableIndexAccessNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/nullability/NullableIndexAccessNode.java
@@ -1,0 +1,60 @@
+package water.compiler.parser.nodes.nullability;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import water.compiler.FileContext;
+import water.compiler.compiler.Context;
+import water.compiler.compiler.SemanticException;
+import water.compiler.lexer.Token;
+import water.compiler.parser.Node;
+import water.compiler.parser.nodes.operation.IndexAccessNode;
+import water.compiler.util.WaterType;
+
+public class NullableIndexAccessNode implements Node {
+
+	private final Token bracket;
+	private final Node left;
+	private final Node index;
+
+	public NullableIndexAccessNode(Token bracket, Node left, Node index) {
+		this.bracket = bracket;
+		this.left = left;
+		this.index = index;
+	}
+
+	@Override
+	public void visit(FileContext context) throws SemanticException {
+		WaterType returnType = left.getReturnType(context.getContext());
+		if(!returnType.isNullable()) {
+			throw new SemanticException(bracket, "Cannot use '?[' on non-nullable type ('%s')".formatted(left.getReturnType(context.getContext())));
+		}
+
+		Label nullValue = new Label();
+		left.visit(context);
+
+		context.getContext().getMethodVisitor().visitInsn(Opcodes.DUP);
+		context.getContext().getMethodVisitor().visitJumpInsn(Opcodes.IFNULL, nullValue);
+
+		synthetic().visitAccess(context);
+
+		synthetic().getReturnType(context.getContext()).autoBox(context.getContext().getMethodVisitor());
+
+		context.getContext().getMethodVisitor().visitLabel(nullValue);
+	}
+
+	@Override
+	public WaterType getReturnType(Context context) throws SemanticException {
+		WaterType rawType = synthetic().getReturnType(context);
+
+		return rawType.getAutoBoxWrapper().setNullable(true);
+	}
+
+	private IndexAccessNode synthetic() {
+		return new IndexAccessNode(bracket, left, index);
+	}
+
+	@Override
+	public String toString() {
+		return "%s?[%s]".formatted(left, index);
+	}
+}

--- a/Compiler/src/water/compiler/parser/nodes/nullability/NullableIndexAccessNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/nullability/NullableIndexAccessNode.java
@@ -46,7 +46,7 @@ public class NullableIndexAccessNode implements Node {
 	public WaterType getReturnType(Context context) throws SemanticException {
 		WaterType rawType = synthetic().getReturnType(context);
 
-		return rawType.getAutoBoxWrapper().setNullable(true);
+		return rawType.getAutoBoxWrapper().asNullable();
 	}
 
 	private IndexAccessNode synthetic() {

--- a/Compiler/src/water/compiler/parser/nodes/nullability/NullableMemberAccessNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/nullability/NullableMemberAccessNode.java
@@ -43,7 +43,7 @@ public class NullableMemberAccessNode implements Node {
 	public WaterType getReturnType(Context context) throws SemanticException {
 		WaterType rawType = synthetic().getReturnType(context);
 
-		return rawType.getAutoBoxWrapper().setNullable(true);
+		return rawType.getAutoBoxWrapper().asNullable();
 	}
 
 	private MemberAccessNode synthetic() {

--- a/Compiler/src/water/compiler/parser/nodes/nullability/NullableMethodCallNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/nullability/NullableMethodCallNode.java
@@ -50,7 +50,7 @@ public class NullableMethodCallNode implements Node {
 	public WaterType getReturnType(Context context) throws SemanticException {
 		WaterType rawType = synthetic().getReturnType(context);
 
-		return rawType.getAutoBoxWrapper().setNullable(true);
+		return rawType.getAutoBoxWrapper().asNullable();
 	}
 
 	private MethodCallNode synthetic() {

--- a/Compiler/src/water/compiler/parser/nodes/nullability/NullableMethodCallNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/nullability/NullableMethodCallNode.java
@@ -35,10 +35,21 @@ public class NullableMethodCallNode implements Node {
 		}
 
 		Label nullValue = new Label();
+
+		boolean isSettingJump = false;
+		if(context.getContext().getNullJumpLabel(nullValue) == nullValue) {
+			context.getContext().setNullJumpLabel(nullValue);
+			isSettingJump = true;
+		}
+
 		left.visit(context);
 
+		if(isSettingJump) {
+			context.getContext().setNullJumpLabel(null);
+		}
+
 		context.getContext().getMethodVisitor().visitInsn(Opcodes.DUP);
-		context.getContext().getMethodVisitor().visitJumpInsn(Opcodes.IFNULL, nullValue);
+		context.getContext().getMethodVisitor().visitJumpInsn(Opcodes.IFNULL, context.getContext().getNullJumpLabel(nullValue));
 
 		synthetic().visitCall(context);
 		synthetic().getReturnType(context.getContext()).autoBox(context.getContext().getMethodVisitor());

--- a/Compiler/src/water/compiler/parser/nodes/operation/IndexAccessNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/operation/IndexAccessNode.java
@@ -22,6 +22,11 @@ public class IndexAccessNode implements Node {
 
 	@Override
 	public void visit(FileContext context) throws SemanticException {
+		left.visit(context);
+		visitAccess(context);
+	}
+
+	public void visitAccess(FileContext context) throws SemanticException {
 		WaterType leftType = left.getReturnType(context.getContext());
 		WaterType indexType = index.getReturnType(context.getContext());
 
@@ -32,7 +37,6 @@ public class IndexAccessNode implements Node {
 			throw new SemanticException(bracket, "Index must be an integer type (got '%s')".formatted(indexType));
 		}
 
-		left.visit(context);
 		index.visit(context);
 
 		context.getContext().getMethodVisitor().visitInsn(leftType.getElementType().getOpcode(Opcodes.IALOAD));

--- a/Compiler/src/water/compiler/parser/nodes/operation/IndexAccessNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/operation/IndexAccessNode.java
@@ -23,6 +23,12 @@ public class IndexAccessNode implements Node {
 	@Override
 	public void visit(FileContext context) throws SemanticException {
 		left.visit(context);
+
+		WaterType returnType = left.getReturnType(context.getContext());
+		if(returnType.isNullable()) {
+			throw new SemanticException(bracket, "Cannot use '[' to call methods on a nullable type ('%s')".formatted(returnType));
+		}
+
 		visitAccess(context);
 	}
 

--- a/Compiler/src/water/compiler/parser/nodes/value/ArrayConstructorNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/value/ArrayConstructorNode.java
@@ -51,7 +51,7 @@ public class ArrayConstructorNode implements Node {
 
 	@Override
 	public WaterType getReturnType(Context context) throws SemanticException {
-		return WaterType.getType(getDescriptor(context));
+		return WaterType.getArrayType(type.getReturnType(context), dimensions.size());
 	}
 
 	private String getDescriptor(Context context) throws SemanticException {

--- a/Compiler/src/water/compiler/parser/nodes/value/NullNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/value/NullNode.java
@@ -17,7 +17,7 @@ public class NullNode implements Node {
 
 	@Override
 	public WaterType getReturnType(Context context) throws SemanticException {
-		return WaterType.OBJECT_TYPE.setNullable(true);
+		return WaterType.NULL_TYPE;
 	}
 
 	@Override

--- a/Compiler/src/water/compiler/parser/nodes/value/NullNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/value/NullNode.java
@@ -17,7 +17,7 @@ public class NullNode implements Node {
 
 	@Override
 	public WaterType getReturnType(Context context) throws SemanticException {
-		return WaterType.OBJECT_TYPE;
+		return WaterType.OBJECT_TYPE.setNullable(true);
 	}
 
 	@Override

--- a/Compiler/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -49,7 +49,7 @@ public class TypeNode implements Node {
 			throw new SemanticException(root, "Primitive types cannot be nullable.");
 		}
 
-		if(dimensions != 0) return WaterType.getType("[".repeat(dimensions) + element.getReturnType(context).getDescriptor()).setNullable(isNullable);
+		if(dimensions != 0) return WaterType.getType("[".repeat(dimensions) + element.getReturnType(context).getDescriptor()).asNullable(isNullable);
 
 		if(isPrimitive) return switch (root.getType()) {
 			case VOID -> WaterType.VOID_TYPE;
@@ -65,7 +65,7 @@ public class TypeNode implements Node {
 		};
 
 		try {
-			return WaterType.getType(TypeUtil.classForName(path, context)).setNullable(isNullable);
+			return WaterType.getType(TypeUtil.classForName(path, context)).asNullable(isNullable);
 		} catch (ClassNotFoundException e) {
 			throw new SemanticException(root, "Could not resolve class '%s'".formatted(e.getMessage()));
 		}
@@ -74,7 +74,7 @@ public class TypeNode implements Node {
 	public WaterType getRawClassType() throws SemanticException {
 		if(isPrimitive) throw new SemanticException(root, "Unexpected primitive type");
 
-		return WaterType.getObjectType(path.replace('.', '/')).setNullable(isNullable);
+		return WaterType.getObjectType(path.replace('.', '/')).asNullable(isNullable);
 	}
 
 	public void setNullable(boolean isNullable) {

--- a/Compiler/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -1,6 +1,5 @@
 package water.compiler.parser.nodes.value;
 
-import org.objectweb.asm.Type;
 import water.compiler.FileContext;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
@@ -15,6 +14,7 @@ public class TypeNode implements Node {
 	private final boolean isPrimitive;
 	private final int dimensions;
 	private final TypeNode element;
+	private boolean isNullable;
 
 	public TypeNode(Token value) {
 		this.root = value;
@@ -22,6 +22,7 @@ public class TypeNode implements Node {
 		this.isPrimitive = true;
 		this.dimensions = 0;
 		this.element = null;
+		this.isNullable = false;
 	}
 
 	public TypeNode(Token root, String path) {
@@ -30,6 +31,7 @@ public class TypeNode implements Node {
 		this.isPrimitive = false;
 		this.dimensions = 0;
 		this.element = null;
+		this.isNullable = false;
 	}
 
 	public TypeNode(TypeNode element, int dimensions) {
@@ -38,12 +40,16 @@ public class TypeNode implements Node {
 		this.isPrimitive = false;
 		this.dimensions = dimensions;
 		this.element = element;
+		this.isNullable = false;
 	}
 
 	@Override
 	public WaterType getReturnType(Context context) throws SemanticException {
+		if(isNullable && isPrimitive) {
+			throw new SemanticException(root, "Primitive types cannot be nullable.");
+		}
 
-		if(dimensions != 0) return WaterType.getType("[".repeat(dimensions) + element.getReturnType(context).getDescriptor());
+		if(dimensions != 0) return WaterType.getType("[".repeat(dimensions) + element.getReturnType(context).getDescriptor()).setNullable(isNullable);
 
 		if(isPrimitive) return switch (root.getType()) {
 			case VOID -> WaterType.VOID_TYPE;
@@ -59,7 +65,7 @@ public class TypeNode implements Node {
 		};
 
 		try {
-			return WaterType.getType(TypeUtil.classForName(path, context));
+			return WaterType.getType(TypeUtil.classForName(path, context)).setNullable(isNullable);
 		} catch (ClassNotFoundException e) {
 			throw new SemanticException(root, "Could not resolve class '%s'".formatted(e.getMessage()));
 		}
@@ -68,7 +74,11 @@ public class TypeNode implements Node {
 	public WaterType getRawClassType() throws SemanticException {
 		if(isPrimitive) throw new SemanticException(root, "Unexpected primitive type");
 
-		return WaterType.getObjectType(path.replace('.', '/'));
+		return WaterType.getObjectType(path.replace('.', '/')).setNullable(isNullable);
+	}
+
+	public void setNullable(boolean isNullable) {
+		this.isNullable = isNullable;
 	}
 
 	@Override
@@ -78,8 +88,8 @@ public class TypeNode implements Node {
 
 	@Override
 	public String toString() {
-		if(dimensions != 0) return element.toString() + "[]".repeat(dimensions);
+		if(dimensions != 0) return element.toString() + "[]".repeat(dimensions) + (isNullable ? "?" : "");
 
-		return isPrimitive ? root.getValue() : path;
+		return isPrimitive ? root.getValue() : path + (isNullable ? "?" : "");
 	}
 }

--- a/Compiler/src/water/compiler/parser/nodes/value/TypeNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/value/TypeNode.java
@@ -49,7 +49,7 @@ public class TypeNode implements Node {
 			throw new SemanticException(root, "Primitive types cannot be nullable.");
 		}
 
-		if(dimensions != 0) return WaterType.getType("[".repeat(dimensions) + element.getReturnType(context).getDescriptor()).asNullable(isNullable);
+		if(dimensions != 0) return WaterType.getArrayType(element.getReturnType(context), dimensions).asNullable(isNullable);
 
 		if(isPrimitive) return switch (root.getType()) {
 			case VOID -> WaterType.VOID_TYPE;

--- a/Compiler/src/water/compiler/parser/nodes/variable/AssignmentNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/variable/AssignmentNode.java
@@ -139,7 +139,7 @@ public class AssignmentNode implements Node {
 				if(!WaterType.getType(f.getType()).isAssignableFrom(returnType, context.getContext(), true)) {
 					throw new SemanticException(op,
 							"Cannot assign type '%s' to variable of type '%s'"
-									.formatted(returnType, Type.getType(f.getType())));
+									.formatted(returnType, WaterType.getType(f.getType())));
 				}
 			} catch (ClassNotFoundException e) {
 				throw new SemanticException(op, "Could not resolve class '%s'".formatted(e.getMessage()));

--- a/Compiler/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
+++ b/Compiler/src/water/compiler/parser/nodes/variable/VariableDeclarationNode.java
@@ -185,7 +185,11 @@ public class VariableDeclarationNode implements Node {
 
 	private void generateValue(FileContext context) throws SemanticException {
 		if(value == null) {
-			context.getContext().getMethodVisitor().visitInsn(expectedType.getReturnType(context.getContext()).dummyConstant());
+			WaterType returnType = expectedType.getReturnType(context.getContext());
+			if(!returnType.isNullable() && !returnType.isPrimitive()) throw new SemanticException(name, "Cannot default initialize variable of type '%s'".formatted(
+					returnType
+			));
+			context.getContext().getMethodVisitor().visitInsn(returnType.dummyConstant());
 		}
 		else {
 			value.visit(context);

--- a/Compiler/src/water/compiler/util/TypeUtil.java
+++ b/Compiler/src/water/compiler/util/TypeUtil.java
@@ -195,7 +195,7 @@ public class TypeUtil {
 		try {
 			out:
 			for (Constructor<?> c : constructors) {
-				WaterType[] expectArgs = new WaterType(Type.getType(c)).getArgumentTypes();
+				WaterType[] expectArgs = WaterType.getType(c).getArgumentTypes();
 
 				if (expectArgs.length != argTypes.length) continue;
 

--- a/Compiler/src/water/compiler/util/TypeUtil.java
+++ b/Compiler/src/water/compiler/util/TypeUtil.java
@@ -2,7 +2,6 @@ package water.compiler.util;
 
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import water.compiler.compiler.Context;
 import water.compiler.compiler.SemanticException;
 import water.compiler.lexer.Token;

--- a/Compiler/src/water/compiler/util/WaterClassWriter.java
+++ b/Compiler/src/water/compiler/util/WaterClassWriter.java
@@ -1,0 +1,18 @@
+package water.compiler.util;
+
+import org.objectweb.asm.ClassWriter;
+
+public class WaterClassWriter extends ClassWriter {
+
+	private ClassLoader loader;
+
+	public WaterClassWriter(int flags, ClassLoader loader) {
+		super(flags);
+		this.loader = loader == null ? ClassLoader.getSystemClassLoader() : loader;
+	}
+
+	@Override
+	protected ClassLoader getClassLoader() {
+		return loader;
+	}
+}

--- a/Compiler/src/water/compiler/util/WaterType.java
+++ b/Compiler/src/water/compiler/util/WaterType.java
@@ -67,6 +67,7 @@ public class WaterType {
 		this.asmType = asmType;
 		sort = Sort.values()[asmType.getSort()];
 		this.isNullable = false;
+		this.elementType = asmType.getSort() == Type.ARRAY ? new WaterType(asmType.getElementType()) : null;
 	}
 
 	public WaterType(Sort sort) {

--- a/Compiler/src/water/compiler/util/WaterType.java
+++ b/Compiler/src/water/compiler/util/WaterType.java
@@ -530,6 +530,13 @@ public class WaterType {
 		return asmType.hashCode();
 	}
 
+	public WaterType copy() {
+		WaterType type = new WaterType(asmType);
+		type.sort = sort;
+		type.isNullable = isNullable;
+		return type;
+	}
+
 	/**
 	 * Converts a type to a String.
 	 * This String representation differs from Type.toString()

--- a/Compiler/src/water/compiler/util/WaterType.java
+++ b/Compiler/src/water/compiler/util/WaterType.java
@@ -454,9 +454,22 @@ public class WaterType {
 		}
 	}
 
-	public WaterType setNullable(boolean isNullable) {
-		this.isNullable = isNullable;
-		return this;
+	public WaterType asNullable() {
+		WaterType type = copy();
+		type.isNullable = true;
+		return type;
+	}
+
+	public WaterType asNullable(boolean isNullable) {
+		WaterType type = copy();
+		type.isNullable = isNullable;
+		return type;
+	}
+
+	public WaterType asNonNullable() {
+		WaterType type = copy();
+		type.isNullable = false;
+		return type;
 	}
 
 	public boolean isObject() {

--- a/Compiler/src/water/compiler/util/WaterType.java
+++ b/Compiler/src/water/compiler/util/WaterType.java
@@ -7,6 +7,7 @@ import water.compiler.compiler.Context;
 import water.runtime.annotation.Nullable;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
@@ -626,6 +627,15 @@ public class WaterType {
 
 	public static WaterType getType(Class<?> clazz) {
 		return new WaterType(Type.getType(clazz));
+	}
+
+	public static WaterType getType(Field field) {
+		WaterType type = WaterType.getType(field.getType());
+
+		if(field.getAnnotation(Nullable.class) != null) {
+			type.isNullable = true;
+		}
+		return type;
 	}
 
 	public static WaterType getType(Method method) {

--- a/Compiler/src/water/compiler/util/WaterType.java
+++ b/Compiler/src/water/compiler/util/WaterType.java
@@ -649,6 +649,19 @@ public class WaterType {
 	}
 
 	public static WaterType getType(Constructor<?> constructor) {
-		return new WaterType(Type.getType(constructor));
+		Parameter[] parameters = constructor.getParameters();
+
+		ArrayList<WaterType> parameterTypes = new ArrayList<>();
+		for(Parameter parameter : parameters) {
+			Class<?> typeClass = parameter.getType();
+
+			WaterType type = WaterType.getType(typeClass);
+			if(parameter.getAnnotation(Nullable.class) != null) {
+				type.isNullable = true;
+			}
+			parameterTypes.add(type);
+		}
+
+		return WaterType.getMethodType(WaterType.VOID_TYPE, parameterTypes.toArray(WaterType[]::new));
 	}
 }

--- a/Compiler/src/water/compiler/util/WaterType.java
+++ b/Compiler/src/water/compiler/util/WaterType.java
@@ -45,10 +45,12 @@ public class WaterType {
 
 	private final Type asmType;
 	private final Sort sort;
+	private boolean isNullable;
 
 	public WaterType(Type asmType) {
 		this.asmType = asmType;
 		sort = Sort.values()[asmType.getSort()];
+		this.isNullable = false;
 	}
 
 	/**
@@ -105,6 +107,7 @@ public class WaterType {
 	public boolean isAssignableFrom(WaterType from, Context context, boolean convert) throws ClassNotFoundException {
 		//TODO Null types
 		if(isObject() && from.isObject()) {
+			if(!isNullable() && from.isNullable()) return false;
 			return toClass(context).isAssignableFrom(from.toClass(context));
 		}
 
@@ -441,6 +444,11 @@ public class WaterType {
 		}
 	}
 
+	public WaterType setNullable(boolean isNullable) {
+		this.isNullable = isNullable;
+		return this;
+	}
+
 	public boolean isObject() {
 		return asmType.getSort() == Type.OBJECT;
 	}
@@ -484,6 +492,11 @@ public class WaterType {
 	public Sort getSort() {
 		return sort;
 	}
+
+	public boolean isNullable() {
+		return isNullable;
+	}
+
 	private Type getRawType() {
 		return asmType;
 	}
@@ -515,7 +528,7 @@ public class WaterType {
 	 * @return The String representation
 	 */
 	public String toString() {
-		return switch (asmType.getSort()) {
+		String base = switch (asmType.getSort()) {
 			case Type.VOID -> "void";
 			case Type.BOOLEAN -> "boolean";
 			case Type.CHAR -> "char";
@@ -530,6 +543,8 @@ public class WaterType {
 			case Type.METHOD -> "method"; // Should not be reached
 			default -> null; // Unreachable
 		};
+		if(isNullable) base += "?";
+		return base;
 	}
 
 	public static WaterType getMethodType(String descriptor) {

--- a/Runtime/.gitignore
+++ b/Runtime/.gitignore
@@ -1,0 +1,1 @@
+Runtime.iml

--- a/Runtime/src/module-info.java
+++ b/Runtime/src/module-info.java
@@ -1,0 +1,3 @@
+module water.runtime {
+	exports water.runtime.annotation;
+}

--- a/Runtime/src/water/runtime/annotation/Nullable.java
+++ b/Runtime/src/water/runtime/annotation/Nullable.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.METHOD})
 public @interface Nullable {
 

--- a/Runtime/src/water/runtime/annotation/Nullable.java
+++ b/Runtime/src/water/runtime/annotation/Nullable.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.METHOD})
 public @interface Nullable {
 
 }

--- a/Runtime/src/water/runtime/annotation/Nullable.java
+++ b/Runtime/src/water/runtime/annotation/Nullable.java
@@ -1,0 +1,12 @@
+package water.runtime.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+public @interface Nullable {
+
+}


### PR DESCRIPTION
Implement Null Safety and Nullable types.

A nullable type is represented as `<type>?` and cannot be applied to primitives.
`null` can only be assigned to nullable types, and a nullable type cannot be assigned to a non-nullable type.

The `<value>!` operator (Non-null assertion operator) will check if the nullable type is null, throwing a NPE if it is. Its return type is the non-nullable version of its operand type.

The `?.` and `?[` operators allow for accessing an object's / array's values, properties, and methods, but with a null check first. If the object/array is null, the expression returns null.

The `??` operator will short-circuit, returning its left operand if it is not null, and its right if it is.