### PR TITLE
Import ... as ...

### DIFF
--- a/Compiler/src/water/compiler/parser/Parser.java
+++ b/Compiler/src/water/compiler/parser/Parser.java
@@ -98,9 +98,14 @@ public class Parser {
 		Token importTok = tokens.get(index - 1);
 		Node type = classType();
 
+		Token as = null;
+		if(match(TokenType.AS)) {
+			as = consume(TokenType.IDENTIFIER, "Expected import alias");
+		}
+
 		consume(TokenType.SEMI, "Expected ';' after import");
 
-		return new ImportNode(importTok, type);
+		return new ImportNode(importTok, type, as);
 	}
 
 

--- a/testing/tests/Imports.wtr
+++ b/testing/tests/Imports.wtr
@@ -1,6 +1,8 @@
 import java.util.ArrayList;
+import java.util.LinkedList as LL;
 
 function main() {
 	var sb = new StringBuilder(); // Implicit
 	var al = new ArrayList(); // Explicit
+	var ll = new LL();
 }


### PR DESCRIPTION
Introduces the `import ... as ...` syntax, which will rename an import to an alias.

E.g.
```
import java.util.ArrayList as AL;

function main() {
	var sl = new AL();
	sl.add("Hello");
	println(sl.get(0));
}
```
